### PR TITLE
added monitored state

### DIFF
--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -21,6 +21,10 @@
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.inverted_output">
                     {{ _('Inverted output') }}
                 </label>
+								<label class="checkbox">
+                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.monitor_state">
+                    {{ _('Monitor state') }}
+                </label>
             </div>
             <label class="control-label">{{ _('Icon On') }}</label>
             <div class="controls">


### PR DESCRIPTION
In case when multiple scripts/plugins work with GPIO pins
monitored state allows to skip action if it is already in
desired state.

Only UI update is ran in that case.

Also, update_ui checks if model has been defined already to prevent errors in logs