### PR TITLE
New api entrypoint to get all relays status in one call

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -244,6 +244,8 @@ class OctoRelayPlugin(
         GPIO.setup(relay_pin, GPIO.OUT)
         # XOR with inverted
         ledState = inverted != GPIO.input(relay_pin)
+        
+        # added api command to get led status
         if command == "getStatus":
             return flask.jsonify(status=ledState)
             


### PR DESCRIPTION
Hello,
I created a new entrypoint allowing to get all relays statuses in on call.
Command is listAllStatus
and return is [{"active":false,"id":"r1","name":"Light"},{"active":true,"id":"r2","name":"Printer"}]
limitated of to only the enabled relays in setting.