### PR TITLE
Make `print_started()` only process "active" relay configs.

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -315,7 +315,7 @@ class OctoRelayPlugin(
             autoONforPrint = settings['autoONforPrint']
             active = settings["active"]
             if autoONforPrint and active:
-                self._logger.debug(f"turning on pin: {relay_pin}, index: {index}")
+                self._logger.debug("turning on pin: {}, index: {}".format(relay_pin, index))
                 GPIO.setup(relay_pin, GPIO.OUT)
                 # XOR with inverted
                 GPIO.output(relay_pin, inverted != True)

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -310,11 +310,12 @@ class OctoRelayPlugin(
             settings = self.get_settings_defaults()[index]
             settings.update(self._settings.get([index]))
 
+            relay_pin = int(settings["relay_pin"])
+            inverted = settings['inverted_output']
             autoONforPrint = settings['autoONforPrint']
-            if autoONforPrint:
-                relay_pin = int(settings["relay_pin"])
-                inverted = settings['inverted_output']
-
+            active = settings["active"]
+            if autoONforPrint and active:
+                self._logger.debug(f"turning on pin: {relay_pin}, index: {index}")
                 GPIO.setup(relay_pin, GPIO.OUT)
                 # XOR with inverted
                 GPIO.output(relay_pin, inverted != True)


### PR DESCRIPTION
This fixes an issue with relays not being turned on when a print starts.

I use OctoRelay to control only 1 relay (Pin #18). However there are 7 other placeholder/default configs. One of these placeholder configs happens to also be configured for Pin #18, and has `inverted_output: True` set. After `print_started()` turns on my relay, it then processes the placeholder config and flips it off again.

The debug logs show the conflicting pin configs:
```
settings for r1: {'active': True, 'relay_pin': '18', 'inverted_output': False,
settings for r2: {'active': False, 'relay_pin': 17, 'inverted_output': True,
settings for r3: {'active': False, 'relay_pin': 18, 'inverted_output': True,
[....]
```
_Side note: There seems to be some type confusion. Inactive configs have relay_pin as a int, but active configs have it as a string._

This PR basically makes `print_started()` follow the same logic of `print_stopped()`:
 - Filter for only `active` relays. **[the main fix]**
 - Add debug log statement when actually flipping a pin. **[helpful improvement]**
 - Move definition of`relay_pin` and `inverted` so both functions match. **[code tidy up]**

This should fix these two issues:

- https://github.com/borisbu/OctoRelay/issues/39
- https://github.com/borisbu/OctoRelay/issues/52

_Side note: "active" is not a great choice of name for this variable, as it's similar in meaning to "turned on", which is confusing when managing switches and configs. I think "enabled" would be better, as something can be enabled, but not active. But that's something to fix another time._
