### PR TITLE
CI: ensure testing against OctoPrint 1.8

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -81,7 +81,9 @@ jobs:
       - name: Install OctoPrint
         run: pip install octoprint~=${{ matrix.octoprint }}.0
       - name: Install OctoRelay
-        run: pip install -e .
+        run: |
+          pip install wheel
+          pip install -e .
       - name: Prepare testing environment
         run: pip install coverage
       - name: Test

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -60,6 +60,8 @@ jobs:
         exclude:
           - python: 3.11
             octoprint: 1.8
+          - python: 3.10
+            octoprint: 1.8
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,6 +57,9 @@ jobs:
       matrix:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
         octoprint: [ "1.8", "1.9" ]
+        exclude:
+          - python: 3.11
+            octoprint: 1.8
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -58,6 +58,7 @@ jobs:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
         octoprint: [ "1.8", "1.9" ]
         exclude:
+          # These versions are not compatible to each other:
           - python: 3.11
             octoprint: 1.8
           - python: 3.10
@@ -79,11 +80,14 @@ jobs:
           path: ${{ steps.pipCache.outputs.dir }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-python-${{ matrix.python }}-octoprint-${{ matrix.octoprint}}
       - name: Install OctoPrint
+        # see https://stackoverflow.com/questions/49854628/how-do-i-pip-install-the-latest-patch-number-of-a-package
         run: pip install octoprint~=${{ matrix.octoprint }}.0
+      - name: Install Wheel
+        # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
+        if: matrix.octoprint == '1.8'
+        run: pip install wheel
       - name: Install OctoRelay
-        run: |
-          pip install wheel
-          pip install -e .
+        run: pip install -e .
       - name: Prepare testing environment
         run: pip install coverage
       - name: Test

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -74,7 +74,7 @@ jobs:
           path: ${{ steps.pipCache.outputs.dir }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-python-${{ matrix.python }}-octoprint-${{ matrix.octoprint}}
       - name: Install OctoPrint
-        run: pip install octoprint~=${{ matrix.octoprint }}
+        run: pip install octoprint~=${{ matrix.octoprint }}.0
       - name: Install OctoRelay
         run: pip install -e .
       - name: Prepare testing environment


### PR DESCRIPTION
It turned out that #89 did not actually force to install OctoPrint 1.8.
This PR should fix this.

Tested versions:
- OctoPrint 1.8: on Python 3.7–3.9
- OctoPrint 1.9: on Python 3.7-3.11