### PR TITLE
Listing the required API param `pin`.

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -202,9 +202,9 @@ class OctoRelayPlugin(
 
     def get_api_commands(self):
         return {
-            "update": [],
-            "getStatus": [],
-            "listAllStatus":[],
+            "update": ["pin"],
+            "getStatus": ["pin"],
+            "listAllStatus": [],
         }
 
     def on_api_command(self, command, data):

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -184,7 +184,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_get_api_commands(self):
-        expected = { "update": [], "getStatus": [], "listAllStatus": [] }
+        expected = { "update": [ "pin" ], "getStatus": [ "pin" ], "listAllStatus": [] }
         actual = self.plugin_instance.get_api_commands()
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
The issue originally fixed by @jneilliii in #44 
I'm cherry-picking it into another PR in order to release the fix separately.
Closes #96 