### PR TITLE
Prohibit operating relays for readonly users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Version 2
 
+### 2.1.0
+
+- This version contains an important security fix:
+  - Read only users are prohibited from switching the relays.
+    - Including automations by "Auto ON/OFF on boot" and "before/after printing" settings.
+    - Including related OS commands associated with relay toggling.
+  - Thanks to [@plazarch](https://github.com/plazarch) for reporting the important security flaw.
+- This version introduces a custom permission: "Relay switching".
+  - The following groups are granted that permission by default: admins and users (operators).
+  - You can allow relay switching to other ones in "Access control" section of OctoPrint settings.
+
 ### 2.0.2
 
 - Fixed missing requirement on the `pin` parameter for API commands `update` and `getStatus`.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ or manually using this URL:
 
 > https://github.com/borisbu/OctoRelay/archive/master.zip
 
+In case you want to enable the plugin for user groups other than admins and users (operators), you need to 
+grant them the permission "Relay switching" in the "Access control" section of OctoPrint settings.
+
 ## Configuration
 
 ![Settings panel](img/settings.png)

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -336,7 +336,7 @@ class OctoRelayPlugin(
             autoONforPrint = settings['autoONforPrint']
             cmdON = settings['cmdON']
             active = settings["active"]
-            if autoONforPrint and active:
+            if autoONforPrint and active and self.has_switch_permission():
                 self._logger.debug("turning on pin: {}, index: {}".format(relay_pin, index))
                 self.turn_on_pin(relay_pin, inverted, cmdON)
         self.update_ui()
@@ -352,7 +352,7 @@ class OctoRelayPlugin(
             autoOffDelay = int(settings['autoOffDelay'])
             cmdOFF = settings['cmdOFF']
             active = settings["active"]
-            if autoOFFforPrint and active:
+            if autoOFFforPrint and active and self.has_switch_permission():
                 self._logger.debug("turn off pin: {} in {} seconds. index: {}".format(
                     relay_pin, autoOffDelay, index))
                 self.turn_off_timers[index] = ResettableTimer(

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -6,6 +6,7 @@ from octoprint.events import Events
 from octoprint.util import ResettableTimer
 from octoprint.util import RepeatedTimer
 from octoprint.access import ADMIN_GROUP, USER_GROUP
+from octoprint.access.permissions import Permissions
 
 import flask
 import RPi.GPIO as GPIO
@@ -251,6 +252,9 @@ class OctoRelayPlugin(
             return flask.jsonify(status=ledState)
             
         else:
+            if not Permissions.PLUGIN_OCTORELAY_SWITCH.can():
+                return flask.abort(403)
+
             self._logger.debug("Ocotrelay before pin: {}, inverted: {}, currentState: {}".format(
                 relay_pin,
                 inverted,

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -375,7 +375,7 @@ class OctoRelayPlugin(
             settings[index].update(self._settings.get([index]))
 
             labelText = settings[index]["labelText"]
-            active = int(settings[index]["active"])
+            active = int(settings[index]["active"] and self.has_switch_permission()) # issue 51
             relay_pin = int(settings[index]["relay_pin"])
             inverted = settings[index]['inverted_output']
             iconOn = settings[index]['iconOn']

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -180,7 +180,7 @@ class OctoRelayPlugin(
             self._logger.debug("settings for {}: {}".format(index, settings[index]))
 
             self.model[index] = dict()
-            if settings[index]['active']:
+            if settings[index]['active'] and self.has_switch_permission():
                 relay_pin = int(settings[index]['relay_pin'])
                 initial_value = settings[index]['initial_value']
                 inverted_output = settings[index]['inverted_output']

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -209,6 +209,12 @@ class OctoRelayPlugin(
             "listAllStatus": [],
         }
 
+    def has_switch_permission(self):
+        try:
+            return Permissions.PLUGIN_OCTORELAY_SWITCH.can() # may raise UnknownPermission(key)
+        except Exception:
+            return False
+
     def on_api_command(self, command, data):
         self._logger.debug("on_api_command {}, some_parameter is {}".format(command,data))
 
@@ -252,7 +258,7 @@ class OctoRelayPlugin(
             return flask.jsonify(status=ledState)
             
         else:
-            if not Permissions.PLUGIN_OCTORELAY_SWITCH.can():
+            if not self.has_switch_permission():
                 return flask.abort(403)
 
             self._logger.debug("Ocotrelay before pin: {}, inverted: {}, currentState: {}".format(

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -440,7 +440,7 @@ class OctoRelayPlugin(
             "key": "SWITCH",
             "name": "Switching relays ON and OFF",
             "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
-            "roles": [ "default" ],
+            "roles": [ "switch" ],
             "dangerous": False,
             "default_groups": [ ADMIN_GROUP, USER_GROUP ]
         }]

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -212,8 +212,8 @@ class OctoRelayPlugin(
     def get_additional_permissions(self):
         return [{
             "key": "SWITCH",
-            "name": "Switching relays ON and OFF",
-            "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
+            "name": "Relay switching",
+            "description": "Allows switch GPIO pins and execute related OS commands.",
             "roles": [ "switch" ],
             "dangerous": False,
             "default_groups": [ ADMIN_GROUP, USER_GROUP ]

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -5,6 +5,7 @@ import octoprint.plugin
 from octoprint.events import Events
 from octoprint.util import ResettableTimer
 from octoprint.util import RepeatedTimer
+from octoprint.access import ADMIN_GROUP, USER_GROUP
 
 import flask
 import RPi.GPIO as GPIO
@@ -424,10 +425,22 @@ class OctoRelayPlugin(
                 self.update_ui()
                 break
 
+    def get_additional_permissions(self):
+        return [{
+            "key": "SWITCHING",
+            "name": "Switching relays ON and OFF",
+            "description": "Allows to toggle the GPIO pins and execute OS commands associated with them",
+            "roles": [ "default" ],
+            "dangerous": False,
+            "default_groups": [ ADMIN_GROUP, USER_GROUP ]
+        }]
+
 __plugin_pythoncompat__ = ">=3.7,<4"
 __plugin_implementation__ = OctoRelayPlugin()
 
 __plugin_hooks__ = {
     "octoprint.plugin.softwareupdate.check_config":
-        __plugin_implementation__.get_update_information
+        __plugin_implementation__.get_update_information,
+    "octoprint.access.permissions":
+        __plugin_implementation__.get_additional_permissions
 }

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -427,9 +427,9 @@ class OctoRelayPlugin(
 
     def get_additional_permissions(self):
         return [{
-            "key": "SWITCHING",
+            "key": "SWITCH",
             "name": "Switching relays ON and OFF",
-            "description": "Allows to toggle the GPIO pins and execute OS commands associated with them",
+            "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
             "roles": [ "default" ],
             "dangerous": False,
             "default_groups": [ ADMIN_GROUP, USER_GROUP ]

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -208,6 +208,16 @@ class OctoRelayPlugin(
             "getStatus": ["pin"],
             "listAllStatus": [],
         }
+    
+    def get_additional_permissions(self):
+        return [{
+            "key": "SWITCH",
+            "name": "Switching relays ON and OFF",
+            "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
+            "roles": [ "switch" ],
+            "dangerous": False,
+            "default_groups": [ ADMIN_GROUP, USER_GROUP ]
+        }]
 
     def has_switch_permission(self):
         try:
@@ -434,16 +444,6 @@ class OctoRelayPlugin(
                 self._logger.debug("relay: {} has changed its pin state".format(index))
                 self.update_ui()
                 break
-
-    def get_additional_permissions(self):
-        return [{
-            "key": "SWITCH",
-            "name": "Switching relays ON and OFF",
-            "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
-            "roles": [ "switch" ],
-            "dangerous": False,
-            "default_groups": [ ADMIN_GROUP, USER_GROUP ]
-        }]
 
 __plugin_pythoncompat__ = ">=3.7,<4"
 __plugin_implementation__ = OctoRelayPlugin()

--- a/octoprint_octorelay/templates/octorelay_navbar.jinja2
+++ b/octoprint_octorelay/templates/octorelay_navbar.jinja2
@@ -1,5 +1,5 @@
 {% for n in range(1,9) %}
-    <div id="relaisr{{n}}" style="float: left; padding: 8px; font-size: 1.3em; {% if n > 4 %} display:none; {% endif %}">
+    <div id="relaisr{{n}}" style="float: left; padding: 8px; font-size: 1.3em; display: none;">
         <a
             id="ralayIconr{{n}}"
             title="relay {{n}}"
@@ -23,4 +23,3 @@
         <button class="btn btn-danger btn-confirm">Confirm</button>
     </div>
 </div>
-

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -288,6 +288,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                     "confirmOff": False
                 }
             self.plugin_instance.update_ui()
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
             for index in self.plugin_instance.get_settings_defaults():
                 self.plugin_instance._settings.get.assert_any_call([index])
             self.plugin_instance._plugin_manager.send_plugin_message.assert_called_with(
@@ -352,7 +353,6 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_on_after_startup(self):
         # Depending on actual settings should set the pins state, update UI and start polling
         self.plugin_instance.update_ui = Mock()
-        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         cases = [
             { "inverted": True, "initial": True, "expectedOutput": False },
             { "inverted": True, "initial": False, "expectedOutput": True },
@@ -360,6 +360,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             { "inverted": False, "initial": False, "expectedOutput": False }
         ]
         for case in cases:
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
             settingValueMock = {
                 "active": True,
                 "relay_pin": 17,
@@ -381,8 +382,6 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # For relays configured with autoON should call turn_on_pin method and update UI
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.turn_off_timers = { "test": timerMock }
-        self.plugin_instance.turn_on_pin = Mock()
-        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         self.mockModel()
         cases = [
             { "autoOn": True, "inverted": True, "expectedCall": True},
@@ -391,7 +390,8 @@ class TestOctoRelayPlugin(unittest.TestCase):
             { "autoOn": False, "inverted": False, "expectedCall": False }
         ]
         for case in cases:
-            self.plugin_instance.turn_on_pin.reset_mock()
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
+            self.plugin_instance.turn_on_pin = Mock()
             settingValueMock = {
                 "active": True,
                 "relay_pin": 17,
@@ -401,11 +401,12 @@ class TestOctoRelayPlugin(unittest.TestCase):
             }
             self.plugin_instance._settings.get = Mock(return_value=settingValueMock)
             self.plugin_instance.print_started()
-            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
             timerMock.cancel.assert_called_with()
             if case["expectedCall"]:
+                permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
                 self.plugin_instance.turn_on_pin.assert_called_with(17, case["inverted"], "CommandMock")
             else:
+                permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_not_called()
                 self.plugin_instance.turn_on_pin.assert_not_called()
             self.plugin_instance.update_ui.assert_called_with()
 
@@ -431,13 +432,13 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # For relays with autoOff feature should set timer to turn its pin off
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.turn_off_timers = { "r4": timerMock }
-        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         self.mockModel()
         cases = [
             { "autoOff": True, "expectedCall": True },
             { "autoOff": False, "expectedCall": False },
         ]
         for case in cases:
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
             utilMock.ResettableTimer.reset_mock()
             timerMock.start.reset_mock()
             settingValueMock = {
@@ -450,13 +451,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
             }
             self.plugin_instance._settings.get = Mock(return_value=settingValueMock)
             self.plugin_instance.print_stopped()
-            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
             if case["expectedCall"]:
+                permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
                 utilMock.ResettableTimer.assert_called_with(
                     300, self.plugin_instance.turn_off_pin, [17, False, "CommandMock"]
                 )
                 timerMock.start.assert_called_with()
             else:
+                permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_not_called()
                 utilMock.ResettableTimer.assert_not_called()
                 timerMock.start.assert_not_called()
             self.plugin_instance.update_ui.assert_called_with()
@@ -480,7 +482,6 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Depending on command should perform different actions and response with JSON
         self.plugin_instance.update_ui = Mock()
         GPIO_mock.input = Mock(return_value=True)
-        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         cases = [
             {
                 "command": "listAllStatus",
@@ -542,6 +543,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             }
         ]
         for case in cases:
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
             settingValueMock = {
                 "active": True,
                 "relay_pin": 17,

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -467,6 +467,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         for case in cases:
             permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = case["mock"]
             actual = self.plugin_instance.has_switch_permission()
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
             self.assertEqual(actual, case["expected"])
 
     @patch('flask.jsonify')
@@ -475,7 +476,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Depending on command should perform different actions and response with JSON
         self.plugin_instance.update_ui = Mock()
         GPIO_mock.input = Mock(return_value=True)
-        self.plugin_instance.has_switch_permission = Mock(return_value=True)
+        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         cases = [
             {
                 "command": "listAllStatus",
@@ -569,6 +570,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.plugin_instance._settings.get = Mock(return_value=settingValueMock)
         permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=False)
         self.plugin_instance.on_api_command("update", { "pin": "r4" })
+        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
         abortMock.assert_called_with(403)
 
     def test_get_additional_permissions(self):

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -582,8 +582,8 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_get_additional_permissions(self):
         expected = [{
             "key": "SWITCH",
-            "name": "Switching relays ON and OFF",
-            "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
+            "name": "Relay switching",
+            "description": "Allows switch GPIO pins and execute related OS commands.",
             "roles": [ "switch" ],
             "dangerous": False,
             "default_groups": [ ADMIN_GROUP, USER_GROUP ]

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -352,6 +352,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_on_after_startup(self):
         # Depending on actual settings should set the pins state, update UI and start polling
         self.plugin_instance.update_ui = Mock()
+        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         cases = [
             { "inverted": True, "initial": True, "expectedOutput": False },
             { "inverted": True, "initial": False, "expectedOutput": True },
@@ -367,6 +368,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             }
             self.plugin_instance._settings.get = Mock(return_value=settingValueMock)
             self.plugin_instance.on_after_startup()
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
             GPIO_mock.setup.assert_called_with(17, "MockedOUT")
             GPIO_mock.output.assert_called_with(17, case["expectedOutput"])
             self.plugin_instance.update_ui.assert_called_with()

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -382,6 +382,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.turn_off_timers = { "test": timerMock }
         self.plugin_instance.turn_on_pin = Mock()
+        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         self.mockModel()
         cases = [
             { "autoOn": True, "inverted": True, "expectedCall": True},
@@ -400,6 +401,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             }
             self.plugin_instance._settings.get = Mock(return_value=settingValueMock)
             self.plugin_instance.print_started()
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
             timerMock.cancel.assert_called_with()
             if case["expectedCall"]:
                 self.plugin_instance.turn_on_pin.assert_called_with(17, case["inverted"], "CommandMock")
@@ -429,6 +431,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # For relays with autoOff feature should set timer to turn its pin off
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.turn_off_timers = { "r4": timerMock }
+        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         self.mockModel()
         cases = [
             { "autoOff": True, "expectedCall": True },
@@ -447,6 +450,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             }
             self.plugin_instance._settings.get = Mock(return_value=settingValueMock)
             self.plugin_instance.print_stopped()
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
             if case["expectedCall"]:
                 utilMock.ResettableTimer.assert_called_with(
                     300, self.plugin_instance.turn_off_pin, [17, False, "CommandMock"]

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -259,12 +259,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Should send message via plugin manager containing actual settings and the pins state
         self.mockModel()
         GPIO_mock.input = Mock(return_value=False)
-        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         cases = [
-            { "inverted": True, "expectedIcon": "ON" },
-            { "inverted": False, "expectedIcon": "OFF" }
+            { "inverted": True, "permission": True, "expectedIcon": "ON", "expectedActive": True },
+            { "inverted": False, "permission": True, "expectedIcon": "OFF", "expectedActive": True },
+            { "inverted": True, "permission": False, "expectedIcon": "ON", "expectedActive": False },
+            { "inverted": False, "permission": False, "expectedIcon": "OFF", "expectedActive": False }
         ]
         for case in cases:
+            permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=case["permission"])
             settingValueMock = {
                 "active": True,
                 "relay_pin": 17,
@@ -281,7 +283,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                     "relay_pin": 17,
                     "state": False,
                     "labelText": "TEST",
-                    "active": True,
+                    "active": case["expectedActive"],
                     "iconText": case["expectedIcon"],
                     "confirmOff": False
                 }

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -562,7 +562,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             "key": "SWITCH",
             "name": "Switching relays ON and OFF",
             "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
-            "roles": [ "default" ],
+            "roles": [ "switch" ],
             "dangerous": False,
             "default_groups": [ ADMIN_GROUP, USER_GROUP ]
         }]

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 from unittest.mock import Mock, patch, MagicMock
 from octoprint.events import Events
+from octoprint.access import ADMIN_GROUP, USER_GROUP
 
 # Patching required before importing OctoRelayPlugin class
 GPIO_mock = Mock()
@@ -533,6 +534,18 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 systemMock.assert_called_with(case["expectedCommand"])
             if hasattr(case, "expectedStatus"):
                 json.assert_called_with(status=case["expectedStatus"])
+
+    def test_get_additional_permissions(self):
+        expected = [{
+            "key": "SWITCH",
+            "name": "Switching relays ON and OFF",
+            "description": "Allows to toggle the GPIO pins and execute the associated OS commands.",
+            "roles": [ "default" ],
+            "dangerous": False,
+            "default_groups": [ ADMIN_GROUP, USER_GROUP ]
+        }]
+        actual = self.plugin_instance.get_additional_permissions()
+        self.assertEqual(actual, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -455,6 +455,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Depending on command should perform different actions and response with JSON
         self.plugin_instance.update_ui = Mock()
         GPIO_mock.input = Mock(return_value=True)
+        self.plugin_instance.has_switch_permission = Mock(return_value=True)
         cases = [
             {
                 "command": "listAllStatus",

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -406,9 +406,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_print_started__exception(self):
         # Should handle a possible exception when cancelling the timer
         self.plugin_instance.update_ui = Mock()
-        def cancelMock():
-            raise Exception("Sample message")
-        self.plugin_instance.turn_off_timers = { "test": Mock(cancel=cancelMock) }
+        self.plugin_instance.turn_off_timers = { "test": Mock( cancel=Mock(side_effect=Exception) ) }
         self.plugin_instance.turn_on_pin = Mock()
         self.mockModel()
         settingValueMock = {
@@ -457,16 +455,10 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     def test_has_switch_permission(self):
         # Should proxy the permission and handle a possible exception
-        def positive():
-            return True
-        def negative():
-            return False
-        def faulty():
-            raise Exception("Sample message")
         cases = [
-            { "mock": positive, "expected": True },
-            { "mock": negative, "expected": False },
-            { "mock": faulty, "expected": False }
+            { "mock": Mock(return_value=True), "expected": True },
+            { "mock": Mock(return_value=False), "expected": False },
+            { "mock": Mock(side_effect=Exception), "expected": False }
         ]
         for case in cases:
             permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = case["mock"]

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -222,7 +222,9 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_exposed_hooks(self):
         expected = {
             "octoprint.plugin.softwareupdate.check_config":
-                __plugin_implementation__.get_update_information
+                __plugin_implementation__.get_update_information,
+            "octoprint.access.permissions":
+                __plugin_implementation__.get_additional_permissions
         }
         self.assertEqual(__plugin_hooks__, expected)
 

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -16,7 +16,9 @@ utilMock = Mock(
 )
 sys.modules['octoprint.util'] = utilMock
 permissionsMock = Mock()
-sys.modules['octoprint.access.permissions'] = Mock(Permissions=permissionsMock)
+sys.modules['octoprint.access.permissions'] = Mock(
+    Permissions=permissionsMock
+)
 
 from __init__ import OctoRelayPlugin
 from __init__ import __plugin_pythoncompat__, __plugin_implementation__, __plugin_hooks__, POLLING_INTERVAL

--- a/octoprint_octorelay/test__init.py
+++ b/octoprint_octorelay/test__init.py
@@ -259,6 +259,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Should send message via plugin manager containing actual settings and the pins state
         self.mockModel()
         GPIO_mock.input = Mock(return_value=False)
+        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
         cases = [
             { "inverted": True, "expectedIcon": "ON" },
             { "inverted": False, "expectedIcon": "OFF" }
@@ -570,6 +571,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             "cmdOFF": "CommandOffMock"
         }
         self.plugin_instance._settings.get = Mock(return_value=settingValueMock)
+        permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=False)
         self.plugin_instance.on_api_command("update", { "pin": "r4" })
         abortMock.assert_called_with(403)
 


### PR DESCRIPTION
Closes #51 

Approach: introducing a custom permission.

- Initially enabled for Admins and Users (Operators).

Constraints:

- Avoid showing the buttons
- Reject the API command `update`
- Avoid toggling relays having "ON initially on boot"
- Avoid toggling relays having "Auto ON/OFF before/after printing"
