### PR TITLE
Hotfix: Reverting a const for templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 2
 
+### 2.2.5
+
+- Hotfix: partial revert of changes from version 2.2.2.
+  - On some OctoPrint installations the values of plugin settings did not appear.
+  - It has been experimentally established that restoring the templates array as an inline return might fix this issue.
+
 ### 2.2.4
 
 - Fixed UI/UX bug.

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -7,7 +7,7 @@ from octoprint.util import ResettableTimer
 from octoprint.util import RepeatedTimer
 from octoprint.access.permissions import Permissions
 
-from octoprint_octorelay.const import DEFAULT_SETTINGS, RELAY_INDEXES, TEMPLATES, ASSETS
+from octoprint_octorelay.const import DEFAULT_SETTINGS, RELAY_INDEXES, ASSETS
 from octoprint_octorelay.const import SWITCH_PERMISSION, UPDATES_CONFIG, POLLING_INTERVAL
 from octoprint_octorelay.const import UPDATE_COMMAND, GET_STATUS_COMMAND, LIST_ALL_COMMAND, AT_COMMAND
 
@@ -39,7 +39,10 @@ class OctoRelayPlugin(
         return DEFAULT_SETTINGS
 
     def get_template_configs(self):
-        return TEMPLATES
+        return [
+            { "type": "navbar", "custom_bindings": False },
+            { "type": "settings", "custom_bindings": False }
+        ]
 
     def get_assets(self):
         return ASSETS

--- a/octoprint_octorelay/const.py
+++ b/octoprint_octorelay/const.py
@@ -127,12 +127,6 @@ DEFAULT_SETTINGS = {
 # Keys of the default settings, used for iterations: [r1...r8]
 RELAY_INDEXES = DEFAULT_SETTINGS.keys()
 
-# Plugin's templates
-TEMPLATES = [
-    { "type": "navbar", "custom_bindings": False },
-    { "type": "settings", "custom_bindings": False }
-]
-
 # Plugin's asset files to automatically include in the core UI
 ASSETS = { "js": [ "js/octorelay.js" ] }
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_package = "octoprint_octorelay"
 plugin_name = "OctoRelay"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "2.2.4"
+plugin_version = "2.2.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Just noticed that in some cases the values of the plugin settings may not appear in OctoPrint.

I have no idea why, but it figured out that keeping templates as inline return fixes this issue.