### PR TITLE
JS: notification stub in sources

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,9 @@ jobs:
     - name: Install UI dependencies
       working-directory: ts
       run: yarn install
+    - name: Explicitly remove stub
+      working-directory: octoprint_octorelay/static/js
+      run: rm octorelay.js
     - name: Build JS
       working-directory: ts
       run: yarn build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### 3.0.0
 
-- Changing the release type to distributable package.
-  - Plugin version is now set automatically from GitHub release using `miniver`.
-  - A workflow creates a package and attaches it as the release's asset.
+- **Breaking changes**
+  - Changing the release type to a distributable package.
+  - Plugin version is now set automatically from a GitHub release using `miniver`.
+  - A workflow creates a package and then attaches it to the release assets.
   - Thus, redundant files are removed from the distribution.
   - The latest release distribution URL has changed to
     `https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip`.
-- **Breaking changes**
-  - When you upgrade the plugin from v2 or v1 you will see that the control buttons are gone.
+  - Once you upgrade the plugin from v2 or v1 you will see that the control buttons are gone.
   - Instead, there will be a warning button ⚠️ having instructions on further steps:
     1. Don't panic.
     2. Please proceed to "Software update" section of the OctoPrint settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,28 @@
 # Changelog
 
-## Version 2
+## Version 3
 
-### 2.3.0
+### 3.0.0
 
 - Changing the release type to distributable package.
   - Plugin version is now set automatically from GitHub release using `miniver`.
-  - A workflow creates a packages and attaches it as the release's asset.
+  - A workflow creates a package and attaches it as the release's asset.
   - Thus, redundant files are removed from the distribution.
-  - The latest release distribution URL has changed to:
+  - The latest release distribution URL has changed to
+    `https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip`.
+- **Breaking changes**
+  - When you upgrade the plugin from v2 or v1 you will see that the control buttons are gone.
+  - Instead, there will be a warning button ⚠️ having instructions on further steps:
+    1. Don't panic.
+    2. Please proceed to "Software update" section of the OctoPrint settings.
+    3. Find the OctoRelay plugin showing `version: unknown` — this is expected.
+    4. There also should be a button to UPDATE the plugin one more time.
+    5. After that the plugin will be updated from the new distribution URL and the control buttons appear again.
+  - Sorry for the inconvenience.
+    - In case there is no button to update, use the "Force check for updates" function on the top.
+    - As a last resort you can always use the URL mentioned above to reinstall the plugin manually.
 
-```    
-https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip
-```
+## Version 2
 
 ### 2.2.5
 

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -12,10 +12,11 @@ $(() => {
         dialog
             .find("#octorelay-confirmation-text")
             .text("We switched to distributing the plugin in the form of a specially prepared installation " +
-            "package instead of installing from source. The URL for updates has changed because of this. " +
-            'However, there is no cause for concern. Please go to "Software update" section of OctoPrint ' +
-            "settings and update OctoRelay one more time. We apologize for the inconvenience." +
-            "As a last resort, install manually using the following URL:" +
+            "package instead of offering the installation from sources. " +
+            "The URL for fetching updates has changed because of this. " +
+            'However, there is no cause for concern: please go to "Software update" section of the OctoPrint ' +
+            "settings and update OctoRelay one more time. We apologize for the inconvenience. " +
+            "As a last resort, you can always install it manually using the following URL: " +
             "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip");
         dialog.find(".btn-cancel").hide();
         dialog

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -22,7 +22,7 @@ $(() => {
             "package instead of offering the installation from sources. " +
             "The URL for fetching updates has changed because of this. " +
             'However, there is no cause for concern: please go to "Software update" section of the OctoPrint ' +
-            "settings and update OctoRelay one more time. We apologize for the inconvenience. " +
+            "settings and update OctoRelay one more time. Sorry for the inconvenience. " +
             "As a last resort, you can always install it manually using the following URL: " +
             "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip");
         dialog

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -4,6 +4,8 @@
  *
  * PLEASE NOTE the new URL for installing the distributed package:
  * @link https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip
+ *
+ * The actual JavaScript is compiled from TypeScript during the execution of release workflow.
  */
 $(() => {
     const handleClick = () => {

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -38,13 +38,10 @@ $(() => {
         height: "40px",
         padding: "unset",
         cursor: "pointer",
-        color: "yellow",
         "font-size": "1.25rem",
         "text-decoration": "none",
         "align-items": "center",
         "justify-content": "center",
-        "background-color": "black",
-        "border-radius": "5px",
     })
         .html('<i class="fa fa-warning"></i>')
         .attr("title", "OctoRelay: important notice")

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -45,7 +45,7 @@ $(() => {
         "border-radius": "5px",
     })
         .html('<i class="fa fa-warning"></i>')
-        .attr("title", "Click to read the important notice from OctoRelay")
+        .attr("title", "OctoRelay: important notice")
         .off("click")
         .on("click", handleClick)
         .show();

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -27,8 +27,8 @@ $(() => {
             "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip");
         dialog
             .find(".btn-cancel")
-            .off("click")
             .text("Close")
+            .off("click")
             .on("click", () => {
             dialog.modal("hide");
         });

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -1,0 +1,51 @@
+"use strict";
+/**
+ * WARNING: This is a stub for those who installs the plugin from sources
+ *
+ * PLEASE NOTE the new URL for installing the distributed package:
+ * @link https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip
+ */
+$(() => {
+    const handleClick = () => {
+        const dialog = $("#octorelay-confirmation-dialog");
+        dialog.find(".modal-title").text("OctoRelay needs one more update");
+        dialog
+            .find("#octorelay-confirmation-text")
+            .text("We switched to distributing the plugin in the form of a specially prepared installation " +
+            "package instead of installing from source. The URL for updates has changed because of this. " +
+            'However, there is no cause for concern. Please go to "Software update" section of OctoPrint ' +
+            "settings and update OctoRelay one more time. We apologize for the inconvenience." +
+            "As a last resort, install manually using the following URL:" +
+            "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip");
+        dialog.find(".btn-cancel").hide();
+        dialog
+            .find(".btn-confirm")
+            .off("click")
+            .text("OK")
+            .on("click", () => {
+            dialog.modal("hide");
+        });
+        dialog.modal("show");
+    };
+    $("#relaisr1")
+        .css({
+        display: "flex",
+        float: "left",
+        width: "40px",
+        height: "40px",
+        padding: "unset",
+        cursor: "pointer",
+        color: "yellow",
+        "font-size": "1.25rem",
+        "text-decoration": "none",
+        "align-items": "center",
+        "justify-content": "center",
+        "background-color": "black",
+        "border-radius": "5px",
+    })
+        .show()
+        .html('<i class="fa fa-warning"></i>')
+        .attr("title", "Click to read the important notice from OctoRelay")
+        .off("click")
+        .on("click", handleClick);
+});

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -21,8 +21,8 @@ $(() => {
             .text("We switched to distributing the plugin in the form of a specially prepared installation " +
             "package instead of offering the installation from sources. " +
             "The URL for fetching updates has changed because of this. " +
-            'However, there is no cause for concern: please go to "Software update" section of the OctoPrint ' +
-            "settings and update OctoRelay one more time. Sorry for the inconvenience. " +
+            'However, there is no cause for concern: please proceed to the "Software update" section of the ' +
+            "OctoPrint settings and update OctoRelay one more time. Sorry for the inconvenience. " +
             "As a last resort, you can always install it manually using the following URL: " +
             "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip");
         dialog

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -18,14 +18,14 @@ $(() => {
             "settings and update OctoRelay one more time. We apologize for the inconvenience. " +
             "As a last resort, you can always install it manually using the following URL: " +
             "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip");
-        dialog.find(".btn-cancel").hide();
         dialog
-            .find(".btn-confirm")
+            .find(".btn-cancel")
             .off("click")
-            .text("OK")
+            .text("Close")
             .on("click", () => {
             dialog.modal("hide");
         });
+        dialog.find(".btn-confirm").hide();
         dialog.modal("show");
     };
     $("#relaisr1")
@@ -44,9 +44,9 @@ $(() => {
         "background-color": "black",
         "border-radius": "5px",
     })
-        .show()
         .html('<i class="fa fa-warning"></i>')
         .attr("title", "Click to read the important notice from OctoRelay")
         .off("click")
-        .on("click", handleClick);
+        .on("click", handleClick)
+        .show();
 });

--- a/octoprint_octorelay/static/js/octorelay.js
+++ b/octoprint_octorelay/static/js/octorelay.js
@@ -13,6 +13,11 @@ $(() => {
         dialog.find(".modal-title").text("OctoRelay needs one more update");
         dialog
             .find("#octorelay-confirmation-text")
+            .css({
+            "font-weight": "normal",
+            "font-size": "1rem",
+            "word-wrap": "break-word",
+        })
             .text("We switched to distributing the plugin in the form of a specially prepared installation " +
             "package instead of offering the installation from sources. " +
             "The URL for fetching updates has changed because of this. " +

--- a/ts/package.json
+++ b/ts/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "lint": "eslint ./",
     "test": "tsc --noEmit && jest",
-    "build": "tsc -p ./tsconfig.build.json"
+    "build": "tsc -p ./tsconfig.build.json",
+    "stub": "tsc -p ./tsconfig.stub.json"
   },
   "dependencies": {},
   "devDependencies": {

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -1,0 +1,53 @@
+/**
+ * WARNING: This is a stub for those who installs the plugin from sources
+ *
+ * PLEASE NOTE the new URL for installing the distributed package:
+ * @link https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip
+ */
+
+$(() => {
+  const handleClick = () => {
+    const dialog = $("#octorelay-confirmation-dialog");
+    dialog.find(".modal-title").text("OctoRelay needs one more update");
+    dialog
+      .find("#octorelay-confirmation-text")
+      .text(
+        "We switched to distributing the plugin in the form of a specially prepared installation " +
+          "package instead of installing from source. The URL for updates has changed because of this. " +
+          'However, there is no cause for concern. Please go to "Software update" section of OctoPrint ' +
+          "settings and update OctoRelay one more time. We apologize for the inconvenience." +
+          "As a last resort, install manually using the following URL:" +
+          "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip"
+      );
+    dialog.find(".btn-cancel").hide();
+    dialog
+      .find(".btn-confirm")
+      .off("click")
+      .text("OK")
+      .on("click", () => {
+        dialog.modal("hide");
+      });
+    dialog.modal("show");
+  };
+  $("#relaisr1")
+    .css({
+      display: "flex",
+      float: "left",
+      width: "40px",
+      height: "40px",
+      padding: "unset",
+      cursor: "pointer",
+      color: "yellow",
+      "font-size": "1.25rem",
+      "text-decoration": "none",
+      "align-items": "center",
+      "justify-content": "center",
+      "background-color": "black",
+      "border-radius": "5px",
+    })
+    .show()
+    .html('<i class="fa fa-warning"></i>')
+    .attr("title", "Click to read the important notice from OctoRelay")
+    .off("click")
+    .on("click", handleClick);
+});

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -47,7 +47,7 @@ $(() => {
       "border-radius": "5px",
     })
     .html('<i class="fa fa-warning"></i>')
-    .attr("title", "Click to read the important notice from OctoRelay")
+    .attr("title", "OctoRelay: important notice")
     .off("click")
     .on("click", handleClick)
     .show();

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -20,14 +20,14 @@ $(() => {
           "As a last resort, you can always install it manually using the following URL: " +
           "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip"
       );
-    dialog.find(".btn-cancel").hide();
     dialog
-      .find(".btn-confirm")
+      .find(".btn-cancel")
       .off("click")
-      .text("OK")
+      .text("Close")
       .on("click", () => {
         dialog.modal("hide");
       });
+    dialog.find(".btn-confirm").hide();
     dialog.modal("show");
   };
   $("#relaisr1")
@@ -46,9 +46,9 @@ $(() => {
       "background-color": "black",
       "border-radius": "5px",
     })
-    .show()
     .html('<i class="fa fa-warning"></i>')
     .attr("title", "Click to read the important notice from OctoRelay")
     .off("click")
-    .on("click", handleClick);
+    .on("click", handleClick)
+    .show();
 });

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -13,10 +13,11 @@ $(() => {
       .find("#octorelay-confirmation-text")
       .text(
         "We switched to distributing the plugin in the form of a specially prepared installation " +
-          "package instead of installing from source. The URL for updates has changed because of this. " +
-          'However, there is no cause for concern. Please go to "Software update" section of OctoPrint ' +
-          "settings and update OctoRelay one more time. We apologize for the inconvenience." +
-          "As a last resort, install manually using the following URL:" +
+          "package instead of offering the installation from sources. " +
+          "The URL for fetching updates has changed because of this. " +
+          'However, there is no cause for concern: please go to "Software update" section of the OctoPrint ' +
+          "settings and update OctoRelay one more time. We apologize for the inconvenience. " +
+          "As a last resort, you can always install it manually using the following URL: " +
           "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip"
       );
     dialog.find(".btn-cancel").hide();

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -13,6 +13,11 @@ $(() => {
     dialog.find(".modal-title").text("OctoRelay needs one more update");
     dialog
       .find("#octorelay-confirmation-text")
+      .css({
+        "font-weight": "normal",
+        "font-size": "1rem",
+        "word-wrap": "break-word",
+      })
       .text(
         "We switched to distributing the plugin in the form of a specially prepared installation " +
           "package instead of offering the installation from sources. " +

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -29,8 +29,8 @@ $(() => {
       );
     dialog
       .find(".btn-cancel")
-      .off("click")
       .text("Close")
+      .off("click")
       .on("click", () => {
         dialog.modal("hide");
       });

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -40,13 +40,10 @@ $(() => {
       height: "40px",
       padding: "unset",
       cursor: "pointer",
-      color: "yellow",
       "font-size": "1.25rem",
       "text-decoration": "none",
       "align-items": "center",
       "justify-content": "center",
-      "background-color": "black",
-      "border-radius": "5px",
     })
     .html('<i class="fa fa-warning"></i>')
     .attr("title", "OctoRelay: important notice")

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -3,6 +3,8 @@
  *
  * PLEASE NOTE the new URL for installing the distributed package:
  * @link https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip
+ *
+ * The actual JavaScript is compiled from TypeScript during the execution of release workflow.
  */
 
 $(() => {

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -22,8 +22,8 @@ $(() => {
         "We switched to distributing the plugin in the form of a specially prepared installation " +
           "package instead of offering the installation from sources. " +
           "The URL for fetching updates has changed because of this. " +
-          'However, there is no cause for concern: please go to "Software update" section of the OctoPrint ' +
-          "settings and update OctoRelay one more time. Sorry for the inconvenience. " +
+          'However, there is no cause for concern: please proceed to the "Software update" section of the ' +
+          "OctoPrint settings and update OctoRelay one more time. Sorry for the inconvenience. " +
           "As a last resort, you can always install it manually using the following URL: " +
           "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip"
       );

--- a/ts/stub/octorelay.ts
+++ b/ts/stub/octorelay.ts
@@ -23,7 +23,7 @@ $(() => {
           "package instead of offering the installation from sources. " +
           "The URL for fetching updates has changed because of this. " +
           'However, there is no cause for concern: please go to "Software update" section of the OctoPrint ' +
-          "settings and update OctoRelay one more time. We apologize for the inconvenience. " +
+          "settings and update OctoRelay one more time. Sorry for the inconvenience. " +
           "As a last resort, you can always install it manually using the following URL: " +
           "https://github.com/borisbu/OctoRelay/releases/download/latest/release.zip"
       );

--- a/ts/tsconfig.build.json
+++ b/ts/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
-    "*.spec.ts"
+    "*.spec.ts",
+    "stub"
   ]
 }

--- a/ts/tsconfig.stub.json
+++ b/ts/tsconfig.stub.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "removeComments": false
+  },
+  "exclude": [
+    "*.spec.ts",
+    "./octorelay.ts"
+  ]
+}


### PR DESCRIPTION
Closes #115 
Continuation of #129 — QA revealed a need for a stub

⚠️ Breaking
Switching to ZIP-package distribution requires user to update the plugin TWICE.
After the first update there will be no control buttons in navbar which I consider a disruption of service, requiring a user's action to fix.

In order to minimise the confusion I'm making a stub showing a warning icon for attracting user's attention on the needed action, and a dialog explaining what to do.