### PR TITLE
Testing actual compatibility

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-        octoprint: [ "1.8", "1.9" ]
+        octoprint: [ "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9" ]
         exclude:
           # These versions are not compatible to each other:
           - python: 3.11

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -50,6 +50,7 @@ jobs:
     name: Python ${{ matrix.python }}, OctoPrint ${{ matrix.octoprint }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
         octoprint: [ "1.4", "1.5", "1.6", "1.7", "1.8", "1.9" ]

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -56,8 +56,10 @@ jobs:
         octoprint: [ "1.5", "1.6", "1.7", "1.8", "1.9" ]
         exclude:
           # These versions are not compatible to each other:
-          - octoprint: 1.8
-          - python: [ "3.10", "3.11"]
+          - python: 3.11
+            octoprint: 1.8
+          - python: 3.10
+            octoprint: 1.8
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -56,10 +56,22 @@ jobs:
         octoprint: [ "1.5", "1.6", "1.7", "1.8", "1.9" ]
         exclude:
           # These versions are not compatible to each other:
-          - python: 3.11
-            octoprint: 1.8
-          - python: 3.10
-            octoprint: 1.8
+          - octoprint: 1.5
+            python: 3.10
+          - octoprint: 1.5
+            python: 3.11
+          - octoprint: 1.6
+            python: 3.10
+          - octoprint: 1.6
+            python: 3.11
+          - octoprint: 1.7
+            python: 3.10
+          - octoprint: 1.7
+            python: 3.11
+          - octoprint: 1.8
+            python: 3.11
+          - octoprint: 1.8
+            python: 3.10
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-        octoprint: [ "1.4", "1.5", "1.6", "1.7", "1.8", "1.9" ]
+        octoprint: [ "1.5", "1.6", "1.7", "1.8", "1.9" ]
         exclude:
           # These versions are not compatible to each other:
           - python: 3.11

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -56,10 +56,8 @@ jobs:
         octoprint: [ "1.5", "1.6", "1.7", "1.8", "1.9" ]
         exclude:
           # These versions are not compatible to each other:
-          - python: 3.11
-            octoprint: 1.8
-          - python: 3.10
-            octoprint: 1.8
+          - octoprint: 1.8
+          - python: [ "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -50,7 +50,6 @@ jobs:
     name: Python ${{ matrix.python }}, OctoPrint ${{ matrix.octoprint }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
         octoprint: [ "1.5", "1.6", "1.7", "1.8", "1.9" ]

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -68,9 +68,9 @@ jobs:
           - octoprint: 1.7
             python: 3.11
           - octoprint: 1.8
-            python: 3.11
-          - octoprint: 1.8
             python: 3.10
+          - octoprint: 1.8
+            python: 3.11
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -90,7 +90,7 @@ jobs:
         run: pip install octoprint~=${{ matrix.octoprint }}.0
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
-        # if: matrix.octoprint == '1.8'
+        if: matrix.octoprint != '1.9'
         run: pip install wheel
       - name: Install OctoRelay
         run: pip install -e .

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -78,7 +78,7 @@ jobs:
         run: pip install octoprint~=${{ matrix.octoprint }}.0
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
-        if: matrix.octoprint == '1.8'
+        # if: matrix.octoprint == '1.8'
         run: pip install wheel
       - name: Install OctoRelay
         run: pip install -e .

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-        octoprint: [ "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9" ]
+        octoprint: [ "1.4", "1.5", "1.6", "1.7", "1.8", "1.9" ]
         exclude:
           # These versions are not compatible to each other:
           - python: 3.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
         run: pip install octoprint~=${{ matrix.octoprint }}.0
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
-        if: matrix.octoprint == '1.8'
+        if: matrix.octoprint != '1.9'
         run: pip install wheel
       - name: Install the distributed package
         run: pip install dist/OctoRelay-*.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,9 +88,9 @@ jobs:
           - octoprint: 1.7
             python: 3.11
           - octoprint: 1.8
-            python: 3.11
-          - octoprint: 1.8
             python: 3.10
+          - octoprint: 1.8
+            python: 3.11
     steps:
       - name: Install Python
         uses: actions/setup-python@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,13 +72,25 @@ jobs:
     strategy:
       matrix:
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-        octoprint: [ "1.8", "1.9" ]
+        octoprint: [ "1.5", "1.6", "1.7", "1.8", "1.9" ]
         exclude:
           # These versions are not compatible to each other:
-          - python: 3.11
-            octoprint: 1.8
-          - python: 3.10
-            octoprint: 1.8
+          - octoprint: 1.5
+            python: 3.10
+          - octoprint: 1.5
+            python: 3.11
+          - octoprint: 1.6
+            python: 3.10
+          - octoprint: 1.6
+            python: 3.11
+          - octoprint: 1.7
+            python: 3.10
+          - octoprint: 1.7
+            python: 3.11
+          - octoprint: 1.8
+            python: 3.11
+          - octoprint: 1.8
+            python: 3.10
     steps:
       - name: Install Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Closes #130 

### Findings

- OctoPrint 1.3 and 1.4 are not supported


This PR increases the release time by 15 seconds but it ensures compatibility of the plugin installation against OctoPrint 1.5-1.9 and Python 3.7-3.11 matrix