### PR TITLE
No double testing of GPIO operation

### DIFF
--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -3,9 +3,7 @@ import unittest
 import sys
 from unittest.mock import Mock
 
-if "octoprint_octorelay.driver" in sys.modules:
-    del sys.modules["octoprint_octorelay.driver"]
-
+# Mocks used for assertions
 GPIO_mock = Mock()
 GPIO_mock.BCM = "MockedBCM"
 GPIO_mock.OUT = "MockedOUT"
@@ -13,7 +11,10 @@ sys.modules["RPi.GPIO"] = GPIO_mock
 
 # pylint: disable=wrong-import-position
 from octoprint_octorelay.driver import Relay
-del sys.modules["octoprint_octorelay"] # avoid keeping __init__.py imported in this test
+
+# avoid keeping other modules automatically imported by this test
+del sys.modules["octoprint_octorelay"]
+del sys.modules["octoprint_octorelay.migrations"]
 
 class TestRelayDriver(unittest.TestCase):
     def test_constructor(self):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -6,13 +6,10 @@ from unittest.mock import Mock
 if "octoprint_octorelay.driver" in sys.modules:
     del sys.modules["octoprint_octorelay.driver"]
 
-if "RPi.GPIO" in sys.modules:
-    GPIO_mock = sys.modules["RPi.GPIO"]
-else:
-    GPIO_mock = Mock()
-    GPIO_mock.BCM = "MockedBCM"
-    GPIO_mock.OUT = "MockedOUT"
-    sys.modules["RPi.GPIO"] = GPIO_mock
+GPIO_mock = Mock()
+GPIO_mock.BCM = "MockedBCM"
+GPIO_mock.OUT = "MockedOUT"
+sys.modules["RPi.GPIO"] = GPIO_mock
 
 # pylint: disable=wrong-import-position
 from octoprint_octorelay.driver import Relay

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -572,7 +572,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "data": { "pin": "r4" },
                 "closed": True,
                 "expectedStatus": "ok",
-                "expectedToggle": False,
+                "expectedToggle": True,
                 "expectedCommand": "CommandOffMock"
             }
         ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -343,7 +343,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     @patch("os.system")
     def test_turn_off_relay(self, system_mock):
-        # Should set the pin state depending on inverted parameter and execute the supplied command
+        # Should turn the relay off and execute the supplied command
         self.plugin_instance.update_ui = Mock()
         cases = [
             { "inverted": True, "expectedOutput": True },
@@ -351,24 +351,22 @@ class TestOctoRelayPlugin(unittest.TestCase):
         ]
         for case in cases:
             self.plugin_instance.turn_off_relay(17, case["inverted"], "CommandMock")
-            GPIO_mock.setup.assert_called_with(17, "MockedOUT")
-            GPIO_mock.output.assert_called_with(17, case["expectedOutput"])
-            GPIO_mock.setwarnings.assert_called_with(True)
+            relayConstructorMock.assert_called_with(17, case["inverted"])
+            relayMock.open.assert_called_with()
             system_mock.assert_called_with("CommandMock")
             self.plugin_instance.update_ui.assert_called_with()
 
     @patch("os.system")
     def test_turn_on_relay(self, system_mock):
-        # Depending on relay type it should set its pin state and execute the supplied command
+        # Should turn the relay on and execute the supplied command
         cases = [
             { "inverted": True, "expectedOutput": False},
             { "inverted": False, "expectedOutput": True },
         ]
         for case in cases:
             self.plugin_instance.turn_on_relay(17, case["inverted"], "CommandMock")
-            GPIO_mock.setup.assert_called_with(17, "MockedOUT")
-            GPIO_mock.output.assert_called_with(17, case["expectedOutput"])
-            GPIO_mock.setwarnings.assert_called_with(True)
+            relayConstructorMock.assert_called_with(17, case["inverted"])
+            relayMock.close.assert_called_with()
             system_mock.assert_called_with("CommandMock")
 
     @patch("octoprint.plugin")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,8 +10,7 @@ from octoprint.events import Events
 from octoprint.access import ADMIN_GROUP, USER_GROUP
 
 # Patching required before importing OctoRelayPlugin class
-if "RPi.GPIO" not in sys.modules:
-    sys.modules["RPi.GPIO"] = Mock()
+sys.modules["RPi.GPIO"] = Mock()
 
 timerMock = Mock()
 utilMock = Mock(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,13 +10,8 @@ from octoprint.events import Events
 from octoprint.access import ADMIN_GROUP, USER_GROUP
 
 # Patching required before importing OctoRelayPlugin class
-if "RPi.GPIO" in sys.modules:
-    GPIO_mock = sys.modules["RPi.GPIO"]
-else:
-    GPIO_mock = Mock()
-    GPIO_mock.BCM = "MockedBCM"
-    GPIO_mock.OUT = "MockedOUT"
-    sys.modules["RPi.GPIO"] = GPIO_mock
+if "RPi.GPIO" not in sys.modules:
+    sys.modules["RPi.GPIO"] = Mock()
 
 timerMock = Mock()
 utilMock = Mock(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,18 +12,22 @@ from octoprint.access import ADMIN_GROUP, USER_GROUP
 # Patching required before importing OctoRelayPlugin class
 sys.modules["RPi.GPIO"] = Mock()
 
+# Mocks used for assertions
 timerMock = Mock()
 utilMock = Mock(
     RepeatedTimer = Mock(return_value=timerMock),
     ResettableTimer = Mock(return_value=timerMock)
 )
 sys.modules["octoprint.util"] = utilMock
+
 permissionsMock = Mock()
 sys.modules["octoprint.access.permissions"] = Mock(
     Permissions=permissionsMock
 )
+
 migrationsMock = Mock()
 sys.modules["octoprint_octorelay.migrations"] = migrationsMock
+
 relayMock = Mock()
 relayConstructorMock = Mock(return_value=relayMock)
 sys.modules["octoprint_octorelay.driver"] = Mock(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -30,6 +30,11 @@ sys.modules["octoprint.access.permissions"] = Mock(
 )
 migrationsMock = Mock()
 sys.modules["octoprint_octorelay.migrations"] = migrationsMock
+relayMock = Mock()
+relayConstructorMock = Mock(return_value=relayMock)
+sys.modules["octoprint_octorelay.driver"] = Mock(
+    Relay=relayConstructorMock
+)
 
 # pylint: disable=wrong-import-position
 from octoprint_octorelay import OctoRelayPlugin, __plugin_pythoncompat__, __plugin_implementation__, __plugin_hooks__
@@ -290,8 +295,11 @@ class TestOctoRelayPlugin(unittest.TestCase):
             "r2": { "active": True, "relay_pin": 17, "inverted_output": False, "relay_state": True },
             "r3": { "active": True, "relay_pin": 18, "inverted_output": False, "relay_state": False }
         }
-        GPIO_mock.input = Mock(return_value=1)
+        relayMock.is_closed = Mock(return_value=True)
         self.plugin_instance.input_polling()
+        relayConstructorMock.assert_any_call(4, False)
+        relayConstructorMock.assert_any_call(17, False)
+        relayConstructorMock.assert_any_call(18, False)
         self.plugin_instance.update_ui.assert_called_with()
         self.plugin_instance._logger.debug.assert_called_with("relay: r3 has changed its pin state")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -305,16 +305,18 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     def test_update_ui(self):
         # Should send message via plugin manager containing actual settings and the relay state
-        GPIO_mock.input = Mock(return_value=0)
         cases = [
-            { "inverted": True, "expectedIcon": "ON" },
-            { "inverted": False, "expectedIcon": "OFF" }
+            { "closed": True, "expectedIcon": "ON" },
+            { "closed": False, "expectedIcon": "OFF" }
         ]
         for case in cases:
+            relayMock.pin = 17
+            relayMock.inverted = False
+            relayMock.is_closed = Mock(return_value=case["closed"])
             self.plugin_instance._settings.get = Mock(return_value={
                 "active": True,
-                "relay_pin": 17,
-                "inverted_output": case["inverted"],
+                "relay_pin": relayMock.pin,
+                "inverted_output": False,
                 "iconOn": "ON",
                 "iconOff": "OFF",
                 "labelText": "TEST",
@@ -324,14 +326,15 @@ class TestOctoRelayPlugin(unittest.TestCase):
             for index in self.plugin_instance.get_settings_defaults():
                 expected_model[index] = {
                     "relay_pin": 17,
-                    "inverted_output": case["inverted"],
-                    "relay_state": case["inverted"],
+                    "inverted_output": False,
+                    "relay_state": case["closed"],
                     "labelText": "TEST",
                     "active": True,
                     "iconText": case["expectedIcon"],
                     "confirmOff": False
                 }
             self.plugin_instance.update_ui()
+            relayConstructorMock.assert_called_with(17, False)
             for index in self.plugin_instance.get_settings_defaults():
                 self.plugin_instance._settings.get.assert_any_call([index])
             self.plugin_instance._plugin_manager.send_plugin_message.assert_called_with(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -395,7 +395,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             case["expectedMethod"].assert_called_with()
 
     def test_on_after_startup(self):
-        # Depending on actual settings should set the pins state, update UI and start polling
+        # Depending on actual settings should set the relay state, update UI and start polling
         self.plugin_instance.update_ui = Mock()
         cases = [
             { "inverted": True, "initial": True, "expectedOutput": False },
@@ -411,8 +411,8 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "initial_value": case["initial"]
             })
             self.plugin_instance.on_after_startup()
-            GPIO_mock.setup.assert_called_with(17, "MockedOUT")
-            GPIO_mock.output.assert_called_with(17, case["expectedOutput"])
+            relayConstructorMock.assert_called_with(17, case["inverted"])
+            relayMock.toggle.assert_called_with(case["initial"])
             self.plugin_instance.update_ui.assert_called_with()
             utilMock.RepeatedTimer.assert_called_with(
                 0.3, self.plugin_instance.input_polling, daemon = True

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -4,15 +4,20 @@ import unittest
 import sys
 from unittest.mock import Mock
 
+# Revert mocking by test_init.py
 if "octoprint_octorelay.migrations" in sys.modules:
     del sys.modules["octoprint_octorelay.migrations"]
 
+# Mocks used for assertions
 sys.modules["RPi.GPIO"] = Mock()
 
 # pylint: disable=wrong-import-position
 from octoprint_octorelay.const import SETTINGS_VERSION
 from octoprint_octorelay.migrations import migrators, migrate, v0
-del sys.modules["octoprint_octorelay"] # avoid keeping __init__.py imported in this test
+
+# avoid keeping other modules automatically imported by this test
+del sys.modules["octoprint_octorelay"]
+del sys.modules["octoprint_octorelay.driver"]
 
 class TestMigrations(unittest.TestCase):
     def test_migrators__quantity(self):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -7,13 +7,7 @@ from unittest.mock import Mock
 if "octoprint_octorelay.migrations" in sys.modules:
     del sys.modules["octoprint_octorelay.migrations"]
 
-if "RPi.GPIO" in sys.modules:
-    GPIO_mock = sys.modules["RPi.GPIO"]
-else:
-    GPIO_mock = Mock()
-    GPIO_mock.BCM = "MockedBCM"
-    GPIO_mock.OUT = "MockedOUT"
-    sys.modules["RPi.GPIO"] = GPIO_mock
+sys.modules["RPi.GPIO"] = Mock()
 
 # pylint: disable=wrong-import-position
 from octoprint_octorelay.const import SETTINGS_VERSION

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 if "octoprint_octorelay.migrations" in sys.modules:
     del sys.modules["octoprint_octorelay.migrations"]
 
-# Mocks used for assertions
+# Mocking required before the further import
 sys.modules["RPi.GPIO"] = Mock()
 
 # pylint: disable=wrong-import-position


### PR DESCRIPTION
It's an addition and fix to #138 

This PR:

- avoids testing actual GPIO operation within the plugin's class (it's devoted to driver test)
- fixes the test of API commands
- brings a bit more organization to the imports in tests