### PR TITLE
Feat: AutoConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 3
 
+### 3.3.0
+
+- New feature: AutoConnect.
+  - After turning the printer relay ON the plugin will initiate the connection to printer automatically.
+  - The feature is only availble to users of OctoPrint starting version 1.9.0.
+
 ### 3.2.1
 
 - A minor technical refactoring.

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -167,7 +167,7 @@ class OctoRelayPlugin(
             self.print_stopped()
         elif event == Events.PRINT_FAILED:
             self.print_stopped()
-        elif event == Events.CONNECTIONS_AUTOREFRESHED:
+        elif hasattr(Events, "CONNECTIONS_AUTOREFRESHED") and event == Events.CONNECTIONS_AUTOREFRESHED:
             self._printer.connect()
         #elif event == Events.PRINT_CANCELLING:
             # self.print_stopped()

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -167,8 +167,9 @@ class OctoRelayPlugin(
             self.print_stopped()
         elif event == Events.PRINT_FAILED:
             self.print_stopped()
-        elif hasattr(Events, "CONNECTIONS_AUTOREFRESHED") and event == Events.CONNECTIONS_AUTOREFRESHED:
-            self._printer.connect()
+        elif hasattr(Events, "CONNECTIONS_AUTOREFRESHED"):
+            if event == Events.CONNECTIONS_AUTOREFRESHED:
+                self._printer.connect()
         #elif event == Events.PRINT_CANCELLING:
             # self.print_stopped()
         #elif event == Events.PRINT_CANCELLED:

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -167,7 +167,7 @@ class OctoRelayPlugin(
             self.print_stopped()
         elif event == Events.PRINT_FAILED:
             self.print_stopped()
-        elif hasattr(Events, "CONNECTIONS_AUTOREFRESHED"):
+        elif hasattr(Events, "CONNECTIONS_AUTOREFRESHED"): # Requires OctoPrint 1.9+
             if event == Events.CONNECTIONS_AUTOREFRESHED:
                 self._printer.connect()
         #elif event == Events.PRINT_CANCELLING:

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -167,6 +167,8 @@ class OctoRelayPlugin(
             self.print_stopped()
         elif event == Events.PRINT_FAILED:
             self.print_stopped()
+        elif event == Events.CONNECTIONS_AUTOREFRESHED:
+            self._printer.connect()
         #elif event == Events.PRINT_CANCELLING:
             # self.print_stopped()
         #elif event == Events.PRINT_CANCELLED:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -46,6 +46,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.plugin_instance._logger = Mock()
         self.plugin_instance._settings = Mock()
         self.plugin_instance._plugin_manager = Mock()
+        self.plugin_instance._printer = Mock()
 
     def test_constructor(self):
         # During the instantiation should set initial values to certain props
@@ -386,8 +387,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
             { "event": Events.CLIENT_OPENED, "expectedMethod": self.plugin_instance.update_ui },
             { "event": Events.PRINT_STARTED, "expectedMethod": self.plugin_instance.print_started },
             { "event": Events.PRINT_DONE, "expectedMethod": self.plugin_instance.print_stopped },
-            { "event": Events.PRINT_FAILED, "expectedMethod": self.plugin_instance.print_stopped }
+            { "event": Events.PRINT_FAILED, "expectedMethod": self.plugin_instance.print_stopped },
+
         ]
+        if hasattr(Events, "CONNECTIONS_AUTOREFRESHED"): # Requires OctoPrint 1.9+
+            cases.append({
+                "event": Events.CONNECTIONS_AUTOREFRESHED,
+                "expectedMethod": self.plugin_instance._printer.connect
+            })
         for case in cases:
             self.plugin_instance.on_event(case["event"], "MockedPayload")
             case["expectedMethod"].assert_called_with()


### PR DESCRIPTION
Closes #18 

This will only work for OctoPrint 1.9+

I decided to go without additional setting, a possibility of which (in part of its conditional appearance) is being [discussed on OctoPrint community forum](https://community.octoprint.org/t/binding-to-octoprint-version-or-feature-presence/53272/3). And also without any additional or configurable delay. If there will be an issue of a need I will add it later.