### PR TITLE
Feat: internal events and rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -339,7 +339,7 @@ indent-string='    '
 max-line-length=120
 
 # Maximum number of lines in a module.
-#max-module-lines=1000
+max-module-lines=10000
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/.pylintrc
+++ b/.pylintrc
@@ -339,7 +339,7 @@ indent-string='    '
 max-line-length=120
 
 # Maximum number of lines in a module.
-max-module-lines=1000
+#max-module-lines=1000
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+target="pi@pi.local";
+echo "deploy to octopi: ${target}"
+rsync -avzh octoprint_octorelay/ --delete ${target}:~/oprint/lib/python3.9/site-packages/octoprint_octorelay

--- a/deployAndRestart.sh
+++ b/deployAndRestart.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-target="pi@octopi-dev.local";
-echo "deploy to octopi: ${target}"
-rsync -avzh --exclude='.git/' --exclude='.DS_Store' --exclude='deployAndRestart.sh' --delete . ${target}:~/OctoRelay
-ssh ${target} "~/OctoRelay/installOnPiAndRestart.sh"

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -35,7 +35,7 @@ class OctoRelayPlugin(
     def __init__(self):
         # pylint: disable=super-init-not-called
         self.polling_timer = None
-        self.timers = [] # of { subject: relayIndex, reason: pluginEvent, timer: ResettableTimer }
+        self.tasks = [] # of { subject: relayIndex, reason: pluginEvent, timer: ResettableTimer }
         self.model = {}
         for index in RELAY_INDEXES:
             self.model[index] = {}
@@ -158,7 +158,7 @@ class OctoRelayPlugin(
                 if target is not None:
                     delay = int(settings[index]["rules"][event]["delay"])
                     timer = ResettableTimer(delay, self.toggle_relay, [index, bool(target)])
-                    self.timers.append({
+                    self.tasks.append({
                         "subject": index,
                         "reason": event,
                         "timer": timer
@@ -180,13 +180,13 @@ class OctoRelayPlugin(
 
     # todo: all of them?
     def cancel_timers(self):
-        for index, entry in enumerate(self.timers):
+        for index, entry in enumerate(self.tasks):
             try:
                 entry["timer"].cancel()
                 self._logger.info(f"cancelled timer {index} for relay {entry['subject']}")
             except Exception as exception:
                 self._logger.warn(f"failed to cancel timer {index} for {entry['subject']}, reason: {exception}")
-            self.timers.pop(index)
+            self.tasks.pop(index)
 
     def run_system_command(self, cmd):
         if cmd:

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -175,7 +175,10 @@ class OctoRelayPlugin(
         pin = int(settings["relay_pin"] or 0)
         inverted = bool(settings["inverted_output"])
         relay = Relay(pin, inverted)
-        self._logger.debug(f"Toggling relay {index} on pin {pin}")
+        self._logger.debug(
+            f"Toggling relay {index} on pin {pin}" if target is None else
+            f"Turning the relay {index} {'ON' if target else 'OFF'} (pin {pin})"
+        )
         cmd = settings["cmd_on" if relay.toggle(target) else "cmd_off"]
         self.run_system_command(cmd)
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -159,13 +159,16 @@ class OctoRelayPlugin(
                 if target is not None:
                     self.cancel_tasks(index, event)
                     delay = int(settings[index]["rules"][event]["delay"] or 0)
-                    timer = ResettableTimer(delay, self.toggle_relay, [index, bool(target)])
-                    self.tasks.append({
-                        "subject": index,
-                        "owner": event,
-                        "timer": timer
-                    })
-                    timer.start()
+                    if delay == 0:
+                        self.toggle_relay(index, bool(target))
+                    else:
+                        timer = ResettableTimer(delay, self.toggle_relay, [index, bool(target)])
+                        self.tasks.append({
+                            "subject": index,
+                            "owner": event,
+                            "timer": timer
+                        })
+                        timer.start()
 
     def toggle_relay(self, index, target: Optional[bool] = None):
         settings = self._settings.get([index], merged=True) # expensive

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -35,7 +35,7 @@ class OctoRelayPlugin(
     def __init__(self):
         # pylint: disable=super-init-not-called
         self.polling_timer = None
-        self.tasks = [] # of { subject: relayIndex, reason: pluginEvent, timer: ResettableTimer }
+        self.tasks = [] # of { subject: relayIndex, owner: pluginEvent, timer: ResettableTimer }
         self.model = { index: {} for index in RELAY_INDEXES }
 
     def get_settings_version(self):
@@ -158,7 +158,7 @@ class OctoRelayPlugin(
                     timer = ResettableTimer(delay, self.toggle_relay, [index, bool(target)])
                     self.tasks.append({
                         "subject": index,
-                        "reason": event,
+                        "owner": event,
                         "timer": timer
                     })
                     timer.start()
@@ -180,10 +180,10 @@ class OctoRelayPlugin(
             if index == entry["subject"]: # todo: all of types of events?
                 try:
                     entry["timer"].cancel()
-                    self._logger.info(f"cancelled timer {entry['reason']} for relay {entry['subject']}")
+                    self._logger.info(f"cancelled timer {entry['owner']} for relay {entry['subject']}")
                 except Exception as exception:
                     self._logger.warn(
-                        f"failed to cancel timer {entry['reason']} for {entry['subject']}, reason: {exception}"
+                        f"failed to cancel timer {entry['owner']} for {entry['subject']}, reason: {exception}"
                     )
                 return False # exclude
             return True # include

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -175,9 +175,9 @@ class OctoRelayPlugin(
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
         self.update_ui()
 
-    def cancel_tasks(self, relay: str):
+    def cancel_tasks(self, index: str):
         def handler(entry):
-            if relay == entry["subject"]: # todo: all of types of events?
+            if index == entry["subject"]: # todo: all of types of events?
                 try:
                     entry["timer"].cancel()
                     self._logger.info(f"cancelled timer {entry['reason']} for relay {entry['subject']}")
@@ -185,8 +185,8 @@ class OctoRelayPlugin(
                     self._logger.warn(
                         f"failed to cancel timer {entry['reason']} for {entry['subject']}, reason: {exception}"
                     )
-                return False
-            return True
+                return False # exclude
+            return True # include
         self.tasks = list(filter(handler, self.tasks))
 
     def run_system_command(self, cmd):

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -35,7 +35,7 @@ class OctoRelayPlugin(
     def __init__(self):
         # pylint: disable=super-init-not-called
         self.polling_timer = None
-        self.timers = [] # of { subject: relayIndex, timer: ResettableTimer }
+        self.timers = [] # of { subject: relayIndex, reason: pluginEvent, timer: ResettableTimer }
         self.model = {}
         for index in RELAY_INDEXES:
             self.model[index] = {}
@@ -160,6 +160,7 @@ class OctoRelayPlugin(
                     timer = ResettableTimer(delay, self.toggle_relay, [index, bool(target)])
                     self.timers.append({
                         "subject": index,
+                        "reason": event,
                         "timer": timer
                     })
                     timer.start()

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -11,7 +11,7 @@ from octoprint.util import RepeatedTimer
 from octoprint.access.permissions import Permissions
 
 from .const import (
-    get_default_settings, get_templates, RELAY_INDEXES, ASSETS, SWITCH_PERMISSION, UPDATES_CONFIG,
+    get_default_settings, get_templates, get_ui_vars, RELAY_INDEXES, ASSETS, SWITCH_PERMISSION, UPDATES_CONFIG,
     POLLING_INTERVAL, UPDATE_COMMAND, GET_STATUS_COMMAND, LIST_ALL_COMMAND, AT_COMMAND, SETTINGS_VERSION,
     STARTUP, PRINTING_STOPPED, PRINTING_STARTED, CANCELLATION_EXCEPTIONS
 )
@@ -54,18 +54,7 @@ class OctoRelayPlugin(
         return get_templates()
 
     def get_template_vars(self):
-        return {
-            "events": {
-                STARTUP: "on Startup",
-                PRINTING_STARTED: "on Printing Started",
-                PRINTING_STOPPED: "on Printing Stopped"
-            },
-            "tristate": {
-                "true": "ON",
-                "false": "OFF",
-                "null": "skip"
-            }
-        }
+        return get_ui_vars()
 
     def get_assets(self):
         return ASSETS

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -53,6 +53,20 @@ class OctoRelayPlugin(
     def get_template_configs(self):
         return get_templates()
 
+    def get_template_vars(self):
+        return {
+            "events": {
+                STARTUP: "on Startup",
+                PRINTING_STARTED: "on Printing Started",
+                PRINTING_STOPPED: "on Printing Stopped"
+            },
+            "tristate": {
+                "true": "ON",
+                "false": "OFF",
+                "null": "skip"
+            }
+        }
+
     def get_assets(self):
         return ASSETS
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -175,6 +175,7 @@ class OctoRelayPlugin(
         pin = int(settings["relay_pin"] or 0)
         inverted = bool(settings["inverted_output"])
         relay = Relay(pin, inverted)
+        self._logger.debug(f"Toggling relay {index} on pin {pin}")
         cmd = settings["cmd_on" if relay.toggle(target) else "cmd_off"]
         self.run_system_command(cmd)
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -148,7 +148,7 @@ class OctoRelayPlugin(
             # self.print_stopped()
 
     def handle_plugin_event(self, event):
-        self.cancel_timers() # todo: which ones?
+        self.cancel_tasks() # todo: which ones?
         settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
             if bool(settings[index]["active"]):
@@ -176,7 +176,7 @@ class OctoRelayPlugin(
         self.update_ui()
 
     # todo: all of them?
-    def cancel_timers(self):
+    def cancel_tasks(self):
         for index, entry in enumerate(self.tasks):
             try:
                 entry["timer"].cancel()

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -101,7 +101,7 @@ class OctoRelayPlugin(
             for index in RELAY_INDEXES:
                 if settings[index]["active"]:
                     relay = Relay(
-                        int(settings[index]["relay_pin"]),
+                        int(settings[index]["relay_pin"] or 0),
                         bool(settings[index]["inverted_output"])
                     )
                     active_relays.append({
@@ -115,7 +115,7 @@ class OctoRelayPlugin(
         if command == GET_STATUS_COMMAND:
             settings = self._settings.get([data["pin"]], merged=True) # expensive
             relay = Relay(
-                int(settings["relay_pin"]),
+                int(settings["relay_pin"] or 0),
                 bool(settings["inverted_output"])
             )
             return flask.jsonify(status=relay.is_closed())
@@ -157,7 +157,7 @@ class OctoRelayPlugin(
                 target = settings[index]["rules"][event]["state"]
                 if target is not None:
                     self.cancel_tasks(index, event)
-                    delay = int(settings[index]["rules"][event]["delay"])
+                    delay = int(settings[index]["rules"][event]["delay"] or 0)
                     timer = ResettableTimer(delay, self.toggle_relay, [index, bool(target)])
                     self.tasks.append({
                         "subject": index,
@@ -168,7 +168,7 @@ class OctoRelayPlugin(
 
     def toggle_relay(self, index, target: Optional[bool] = None):
         settings = self._settings.get([index], merged=True) # expensive
-        pin = int(settings["relay_pin"])
+        pin = int(settings["relay_pin"] or 0)
         inverted = bool(settings["inverted_output"])
         relay = Relay(pin, inverted)
         cmd = settings["cmd_on" if relay.toggle(target) else "cmd_off"]
@@ -202,7 +202,7 @@ class OctoRelayPlugin(
         settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
             relay = Relay(
-                int(settings[index]["relay_pin"]),
+                int(settings[index]["relay_pin"] or 0),
                 bool(settings[index]["inverted_output"])
             )
             relay_state = relay.is_closed()

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -129,6 +129,7 @@ class OctoRelayPlugin(
                 self._logger.warn(f"Invalid relay index supplied {index}")
                 return flask.jsonify(status="error")
             self.toggle_relay(index)
+            self.update_ui()
             return flask.jsonify(status="ok")
         return flask.abort(400) # Unknown command
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -163,7 +163,6 @@ class OctoRelayPlugin(
                     })
                     timer.start()
 
-    # todo: should update ui?
     def toggle_relay(self, index, target: Optional[bool] = None):
         settings = self._settings.get([index], merged=True) # expensive
         pin = int(settings["relay_pin"])

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -246,7 +246,7 @@ class OctoRelayPlugin(
 
     # Polling thread
     def input_polling(self):
-        self._logger.debug("input_polling")
+        # self._logger.debug("input_polling") # in case your log file is too small
         for index in RELAY_INDEXES:
             active = self.model[index]["active"]
             model_state = self.model[index]["relay_state"] # bool since v3.1

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -36,9 +36,7 @@ class OctoRelayPlugin(
         # pylint: disable=super-init-not-called
         self.polling_timer = None
         self.tasks = [] # of { subject: relayIndex, reason: pluginEvent, timer: ResettableTimer }
-        self.model = {}
-        for index in RELAY_INDEXES:
-            self.model[index] = {}
+        self.model = { index: {} for index in RELAY_INDEXES }
 
     def get_settings_version(self):
         return SETTINGS_VERSION

--- a/octoprint_octorelay/const.py
+++ b/octoprint_octorelay/const.py
@@ -248,6 +248,10 @@ def get_ui_vars():
             PRINTING_STARTED: "on Printing Started",
             PRINTING_STOPPED: "on Printing Stopped"
         },
+        "boolean": {
+            "true": { "caption": "YES", "color": "info" },
+            "false": { "caption": "NO", "color": "default" }
+        },
         "tristate": {
             "true": { "caption": "ON", "color": "success" },
             "false": { "caption": "OFF", "color": "danger" },

--- a/octoprint_octorelay/const.py
+++ b/octoprint_octorelay/const.py
@@ -254,8 +254,8 @@ def get_ui_vars():
         },
         "tristate": {
             "true": { "caption": "ON", "color": "success" },
-            "false": { "caption": "OFF", "color": "danger" },
             "null": { "caption": "skip", "color": "default" },
+            "false": { "caption": "OFF", "color": "danger" }
         }
     }
 

--- a/octoprint_octorelay/const.py
+++ b/octoprint_octorelay/const.py
@@ -6,6 +6,10 @@ STARTUP = "STARTUP"
 PRINTING_STARTED = "PRINTING_STARTED"
 PRINTING_STOPPED = "PRINTING_STOPPED"
 
+# Task cancellation exceptions
+# { eventHappened: [ events which postponed timers should NOT be cancelled ]
+CANCELLATION_EXCEPTIONS = {}
+
 # Versioning of the plugin's default settings described below
 SETTINGS_VERSION = 3
 

--- a/octoprint_octorelay/const.py
+++ b/octoprint_octorelay/const.py
@@ -249,9 +249,9 @@ def get_ui_vars():
             PRINTING_STOPPED: "on Printing Stopped"
         },
         "tristate": {
-            "true": "ON",
-            "false": "OFF",
-            "null": "skip"
+            "true": { "caption": "ON", "color": "success" },
+            "false": { "caption": "OFF", "color": "danger" },
+            "null": { "caption": "skip", "color": "default" },
         }
     }
 

--- a/octoprint_octorelay/const.py
+++ b/octoprint_octorelay/const.py
@@ -240,6 +240,21 @@ def get_templates():
         { "type": "settings", "custom_bindings": False }
     ]
 
+# these are available in templates with prefix: plugin_octorelay_
+def get_ui_vars():
+    return {
+        "events": {
+            STARTUP: "on Startup",
+            PRINTING_STARTED: "on Printing Started",
+            PRINTING_STOPPED: "on Printing Stopped"
+        },
+        "tristate": {
+            "true": "ON",
+            "false": "OFF",
+            "null": "skip"
+        }
+    }
+
 # Plugin's asset files to automatically include in the core UI
 ASSETS = { "js": [ "js/octorelay.js" ] }
 

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -67,7 +67,7 @@ def v2(settings, logger):
             },
             "PRINTING_STOPPED": {
                 "state": False if bool(auto_off_after_print) else None,
-                "delay": before.get("auto_off_delay")
+                "delay": int(before.get("auto_off_delay") or 0)
             }
         }
         logger.debug(f"replacing it with: {after}")

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -47,17 +47,26 @@ def v2(settings, logger):
         for key, value in before.items():
             if key not in removed:
                 after[key] = value
+        initial_value = before.get("initial_value")
+        if initial_value is None:
+            initial_value = index == "r4" # v2 default: true for r4
+        auto_on_before_print = before.get("auto_on_before_print")
+        if auto_on_before_print is None:
+            auto_on_before_print = index in ["r1", "r3", "r4"] # v2 default, true for these ones
+        auto_off_after_print = before.get("auto_off_after_print")
+        if auto_off_after_print is None:
+            auto_off_after_print = index in ["r1", "r3", "r4"] # v2 default, true for these ones
         after["rules"] = { # no references to constants
             "STARTUP": {
-                "state": before.get("initial_value"),
+                "state": bool(initial_value),
                 "delay": 0
             },
             "PRINTING_STARTED": {
-                "state": True if bool(before.get("auto_on_before_print")) else None,
+                "state": True if bool(auto_on_before_print) else None,
                 "delay": 0
             },
             "PRINTING_STOPPED": {
-                "state": False if bool(before.get("auto_off_after_print")) else None,
+                "state": False if bool(auto_off_after_print) else None,
                 "delay": before.get("auto_off_delay")
             }
         }

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -41,7 +41,7 @@ def v2(settings, logger):
     # There were fields listed in the "removed" const that become rules
     removed = ["initial_value", "auto_on_before_print", "auto_off_after_print", "auto_off_delay"]
     for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]: # no references to constants
-        before = settings.get([index]) # without defaults
+        before = settings.get([index], merged=True) # including defaults
         after = {}
         logger.debug(f"relay {index} stored settings: {before}")
         for key, value in before.items():
@@ -49,16 +49,16 @@ def v2(settings, logger):
                 after[key] = value
         after["rules"] = { # no references to constants
             "STARTUP": {
-                "state": before.get("initial_value"),
+                "state": bool(before["initial_value"]),
                 "delay": 0
             },
             "PRINTING_STARTED": {
-                "state": True if bool(before.get("auto_on_before_print")) else None,
+                "state": True if bool(before["auto_on_before_print"]) else None,
                 "delay": 0
             },
             "PRINTING_STOPPED": {
-                "state": False if bool(before.get("auto_off_after_print")) else None,
-                "delay": before.get("auto_off_delay")
+                "state": False if bool(before["auto_off_after_print"]) else None,
+                "delay": int(before["auto_off_delay"])
             }
         }
         logger.debug(f"replacing it with: {after}")

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -41,7 +41,7 @@ def v2(settings, logger):
     # There were fields listed in the "removed" const that become rules
     removed = ["initial_value", "auto_on_before_print", "auto_off_after_print", "auto_off_delay"]
     for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]: # no references to constants
-        before = settings.get([index], merged=True) # including defaults
+        before = settings.get([index]) # without defaults
         after = {}
         logger.debug(f"relay {index} stored settings: {before}")
         for key, value in before.items():
@@ -49,16 +49,16 @@ def v2(settings, logger):
                 after[key] = value
         after["rules"] = { # no references to constants
             "STARTUP": {
-                "state": bool(before["initial_value"]),
+                "state": before.get("initial_value"),
                 "delay": 0
             },
             "PRINTING_STARTED": {
-                "state": True if bool(before["auto_on_before_print"]) else None,
+                "state": True if bool(before.get("auto_on_before_print")) else None,
                 "delay": 0
             },
             "PRINTING_STOPPED": {
-                "state": False if bool(before["auto_off_after_print"]) else None,
-                "delay": int(before["auto_off_delay"])
+                "state": False if bool(before.get("auto_off_after_print")) else None,
+                "delay": before.get("auto_off_delay")
             }
         }
         logger.debug(f"replacing it with: {after}")

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -80,5 +80,5 @@ def migrate(current: int, settings, logger):
     # Current version number corresponds to the list index to begin migrations from
     jobs = migrators[current::]
     for index, job in enumerate(jobs):
-        logger.info(f"OctoRelay migrates to settings v{index + 1}")
+        logger.info(f"OctoRelay migrates to settings v{current + index + 1}")
         job(settings, logger)

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -42,27 +42,25 @@ def v2(settings, logger):
     removed = ["initial_value", "auto_on_before_print", "auto_off_after_print", "auto_off_delay"]
     for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]: # no references to constants
         before = settings.get([index]) # without defaults
+        after = {}
         logger.debug(f"relay {index} stored settings: {before}")
-        after = {
-            **before,
-            "rules": { # no references to constants
-                "STARTUP": {
-                    "state": before.get("initial_value"),
-                    "delay": 0
-                },
-                "PRINTING_STARTED": {
-                    "state": True if bool(before.get("auto_on_before_print")) else None,
-                    "delay": 0
-                },
-                "PRINTING_STOPPED": {
-                    "state": False if bool(before.get("auto_off_after_print")) else None,
-                    "delay": before.get("auto_off_delay")
-                }
+        for key, value in before.items():
+            if key not in removed:
+                after[key] = value
+        after["rules"] = { # no references to constants
+            "STARTUP": {
+                "state": before.get("initial_value"),
+                "delay": 0
+            },
+            "PRINTING_STARTED": {
+                "state": True if bool(before.get("auto_on_before_print")) else None,
+                "delay": 0
+            },
+            "PRINTING_STOPPED": {
+                "state": False if bool(before.get("auto_off_after_print")) else None,
+                "delay": before.get("auto_off_delay")
             }
         }
-        for key in removed:
-            if key in after:
-                del after[key]
         logger.debug(f"replacing it with: {after}")
         settings.set([index], after)
 

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -95,20 +95,20 @@
                 </div>
 
                 {% for event, label in plugin_octorelay_events.items() %}
-                <div class="control-group">
+                <div class="control-group" data-bind="using: rules.{{event}}">
                     <label class="control-label">{{ _(label) }}</label>
                     <div class="controls">
                         <div class="btn-group">
-                            {% for value, caption in plugin_octorelay_tristate.items() %}
-                            <label class="btn btn-default" data-bind="css: { active: rules.{{event}}.state() === {{value}} }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: rules.{{event}}.state" />
-                                {{ _(caption) }}
+                            {% for value, state in plugin_octorelay_tristate.items() %}
+                            <label class="btn" data-bind="css: { 'active btn-{{state.color}}': state() === {{value}}, 'btn-default': state() !== {{value}} }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: state" />
+                                {{ _(state.caption) }}
                             </label>
                             {% endfor %}
                         </div>
-                        <div class="input-prepend input-append" data-bind="hidden: rules.{{event}}.state() === null">
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
                             <span class="add-on">{{ _('Delay') }}</span>
-                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: rules.{{event}}.delay">
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">{{ _('s') }}</span>
                         </div>
                     </div>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -68,12 +68,29 @@
                     {{ _('Warning on turning OFF') }}
                 </label>
             </div>
+
+
+            <label class="control-label">{{ _('Startup') }}</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">{{ _('Auto ON/OFF') }}</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.initial_value">
-                    {{ _('ON initially on boot') }}
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.auto_on_before_print">
                     {{ _('ON before printing') }}

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -73,18 +73,12 @@
             <label class="control-label">{{ _('Startup') }}</label>
             <div class="controls">
                 <div class="btn-group">
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
-                        ON
+                    {% for value in ["true", "false", "null"] %}
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === {{value}} }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
+                        {{"ON" if value == "true" else "OFF" if value == "false" else "skip"}}
                     </label>
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
-                        no action
-                    </label>
+                    {% endfor %}
                 </div>
             </div>
 

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -14,13 +14,17 @@
                 ></span>
             </label>
         </div>
-        <div data-bind="visible: settings.plugins.octorelay.r{{n}}.active">
+    </div>
+    <div data-bind="visible: settings.plugins.octorelay.r{{n}}.active">
+        <div class="control-group">
             <label class="control-label">{{ _('Label') }}</label>
             <div class="controls">
                 <label class="text">
                     <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.label_text">
                 </label>
             </div>
+        </div>
+        <div class="control-group">
             <label class="control-label">{{ _('GPIO Number') }}</label>
             <div class="controls">
                 <input id="relay_pin-input{{n}}" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.relay_pin">
@@ -29,18 +33,24 @@
                     {{ _('Inverted output') }}
                 </label>
             </div>
+        </div>
+        <div class="control-group">
             <label class="control-label">{{ _('OS Command ON') }}</label>
             <div class="controls">
                 <label class="text">
                     <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_on">
                 </label>
             </div>
+        </div>
+        <div class="control-group">
             <label class="control-label">{{ _('OS Command OFF') }}</label>
             <div class="controls">
                 <label class="text">
                     <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_off">
                 </label>
             </div>
+        </div>
+        <div class="control-group">
             <label class="control-label">{{ _('Icon ON') }}</label>
             <div class="controls">
                 <label class="text">
@@ -51,6 +61,8 @@
                     ></div>
                 </label>
             </div>
+        </div>
+        <div class="control-group">
             <label class="control-label">{{ _('Icon OFF') }}</label>
             <div class="controls">
                 <label class="text">
@@ -61,6 +73,8 @@
                     ></div>
                 </label>
             </div>
+        </div>
+        <div class="control-group">
             <label class="control-label">{{ _('Confirmation') }}</label>
             <div class="controls">
                 <label class="checkbox">
@@ -68,9 +82,10 @@
                     {{ _('Warning on turning OFF') }}
                 </label>
             </div>
+        </div>
 
-
-            {% for event, label in plugin_octorelay_events.items() %}
+        {% for event, label in plugin_octorelay_events.items() %}
+        <div class="control-group">
             <label class="control-label">{{ _(label) }}</label>
             <div class="controls">
                 <div class="btn-group">
@@ -87,10 +102,9 @@
                     <span class="add-on">{{ _('s') }}</span>
                 </div>
             </div>
-            {% endfor %}
-
-
         </div>
+        {% endfor %}
+
     </div>
     {% endfor %}
 </form>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -73,12 +73,16 @@
                 {% endfor %}
 
                 <div class="control-group">
-                    <label class="control-label">{{ _('Confirmation') }}</label>
+                    <label class="control-label">{{ _('Warn when turning OFF') }}</label>
                     <div class="controls">
-                        <label class="checkbox">
-                            <input type="checkbox" data-bind="checked: confirm_off">
-                            {{ _('Warning on turning OFF') }}
-                        </label>
+                        <div class="btn-group">
+                            {% for value, option in plugin_octorelay_boolean.items() %}
+                            <label class="btn" data-bind="css: { 'active btn-{{option.color}}': confirm_off() === {{value}}, 'btn-default': confirm_off() !== {{value}} }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: confirm_off" />
+                                {{ _(option.caption) }}
+                            </label>
+                            {% endfor %}
+                        </div>
                     </div>
                 </div>
 

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -72,7 +72,7 @@
 
             <label class="control-label">{{ _('Startup') }}</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
                         ON

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -81,22 +81,15 @@
                     </label>
                     {% endfor %}
                 </div>
+                <div class="input-prepend input-append" data-bind="hidden: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === null">
+                    <span class="add-on">{{ _('Delay') }}</span>
+                    <input type="number" min="0" max="86400" class="input-mini" data-bind="value: settings.plugins.octorelay.r{{n}}.rules.{{event}}.delay">
+                    <span class="add-on">{{ _('s') }}</span>
+                </div>
             </div>
             {% endfor %}
 
 
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r{{n}}.auto_off_after_print">
-                {{ _('Delay') }}
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r{{n}}.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.auto_off_delay">
-                        <span class="add-on">seconds</span>
-                    </div>
-                    <span class="help-block">{{ _('The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.') }}</span>
-                </label>
-            </div>
         </div>
     </div>
     {% endfor %}

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -14,12 +14,16 @@
         {% for n in range(1,9) %}
         <div id="relay_settings_{{n}}" class="tab-pane" data-bind="css: { active: 1 === {{n}} }, using: settings.plugins.octorelay.r{{n}}">
             <div class="control-group">
-                <label class="control-label">{{ _('Relay') }} {{n}}</label>
+                <label class="control-label">{{ _('Active') }}</label>
                 <div class="controls">
-                    <label class="checkbox">
-                        <input type="checkbox" data-bind="checked: active">
-                        {{ _('Active') }}
-                    </label>
+                    <div class="btn-group">
+                        {% for value, option in plugin_octorelay_boolean.items() %}
+                        <label class="btn" data-bind="css: { 'active btn-{{option.color}}': active() === {{value}}, 'btn-default': active() !== {{value}} }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: active" />
+                            {{ _(option.caption) }}
+                        </label>
+                        {% endfor %}
+                    </div>
                     <span class="help-block" data-bind="hidden: active">
                         {{ _('All operations on this relay are disabled') }}
                     </span>
@@ -36,10 +40,22 @@
                     <label class="control-label">{{ _('GPIO Number') }}</label>
                     <div class="controls">
                         <input id="relay_pin-input{{n}}" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
-                        <label class="checkbox">
-                            <input type="checkbox" data-bind="checked: inverted_output">
-                            {{ _('Inverted output') }}
-                        </label>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('Inverted output') }}</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            {% for value, option in plugin_octorelay_boolean.items() %}
+                            <label class="btn" data-bind="css: { 'active btn-{{option.color}}': inverted_output() === {{value}}, 'btn-default': inverted_output() !== {{value}} }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: inverted_output" />
+                                {{ _(option.caption) }}
+                            </label>
+                            {% endfor %}
+                        </div>
+                        <span class="help-block">
+                            {{ _('For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.') }}
+                        </span>
                     </div>
                 </div>
 

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -59,7 +59,7 @@
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                            style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
                             data-bind="html: icon_on"
                         ></div>
                     </div>
@@ -69,7 +69,7 @@
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                            style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
                             data-bind="html: icon_off"
                         ></div>
                     </div>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -70,14 +70,14 @@
             </div>
 
 
-            {% for event in ["STARTUP", "PRINTING_STARTED", "PRINTING_STOPPED"] %}
-            <label class="control-label">{{ _(event) }}</label>
+            {% for event, label in plugin_octorelay_events.items() %}
+            <label class="control-label">{{ _(label) }}</label>
             <div class="controls">
                 <div class="btn-group">
-                    {% for value in ["true", "false", "null"] %}
+                    {% for value, caption in plugin_octorelay_tristate.items() %}
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === {{value}} }">
                         <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state" />
-                        {{"ON" if value == "true" else "OFF" if value == "false" else "skip"}}
+                        {{ _(caption) }}
                     </label>
                     {% endfor %}
                 </div>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -19,12 +19,10 @@
                     <label class="checkbox">
                         <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.active">
                         {{ _('Active') }}
-                        <span
-                                class="help-inline"
-                                data-bind="hidden: settings.plugins.octorelay.r{{n}}.active, text: settings.plugins.octorelay.r{{n}}.label_text"
-                                style="line-height: initial; vertical-align: unset;"
-                        ></span>
                     </label>
+                    <span class="help-block" data-bind="hidden: settings.plugins.octorelay.r{{n}}.active">
+                        {{ _('All operations on this relay are disabled') }}
+                    </span>
                 </div>
             </div>
             <div data-bind="visible: settings.plugins.octorelay.r{{n}}.active">

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -45,15 +45,6 @@
 
                 {% for state in ["on", "off"] %}
                 <div class="control-group">
-                    <label class="control-label">{{ _('OS Command') }} {{ _(state.upper()) }}</label>
-                    <div class="controls">
-                        <input type="text" class="input-large" data-bind="value: cmd_{{state}}">
-                    </div>
-                </div>
-                {% endfor %}
-
-                {% for state in ["on", "off"] %}
-                <div class="control-group">
                     <label class="control-label">{{ _('Icon') }} {{ _(state.upper()) }}</label>
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_{{state}}">
@@ -92,6 +83,15 @@
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">{{ _('s') }}</span>
                         </div>
+                    </div>
+                </div>
+                {% endfor %}
+
+                {% for state in ["on", "off"] %}
+                <div class="control-group">
+                    <label class="control-label">{{ _('OS Command') }} {{ _(state.upper()) }}</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_{{state}}">
                     </div>
                 </div>
                 {% endfor %}

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -29,9 +29,7 @@
                 <div class="control-group">
                     <label class="control-label">{{ _('Label') }}</label>
                     <div class="controls">
-                        <label class="text">
-                            <input type="text" class="input-small" data-bind="value: label_text">
-                        </label>
+                        <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
                 <div class="control-group">
@@ -47,41 +45,33 @@
                 <div class="control-group">
                     <label class="control-label">{{ _('OS Command ON') }}</label>
                     <div class="controls">
-                        <label class="text">
-                            <input type="text" class="input-large" data-bind="value: cmd_on">
-                        </label>
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
                     </div>
                 </div>
                 <div class="control-group">
                     <label class="control-label">{{ _('OS Command OFF') }}</label>
                     <div class="controls">
-                        <label class="text">
-                            <input type="text" class="input-large" data-bind="value: cmd_off">
-                        </label>
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
                     </div>
                 </div>
                 <div class="control-group">
                     <label class="control-label">{{ _('Icon ON') }}</label>
                     <div class="controls">
-                        <label class="text">
-                            <input type="text" class="input-large" data-bind="value: icon_on">
-                            <div
-                                    style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                                    data-bind="html: icon_on"
-                            ></div>
-                        </label>
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                            style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
+                            data-bind="html: icon_on"
+                        ></div>
                     </div>
                 </div>
                 <div class="control-group">
                     <label class="control-label">{{ _('Icon OFF') }}</label>
                     <div class="controls">
-                        <label class="text">
-                            <input type="text" class="input-large" data-bind="value: icon_off">
-                            <div
-                                    style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                                    data-bind="html: icon_off"
-                            ></div>
-                        </label>
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                            style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
+                            data-bind="html: icon_off"
+                        ></div>
                     </div>
                 </div>
                 <div class="control-group">

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -4,22 +4,37 @@
     <ul class="nav nav-pills">
         {% for n in range(1,9) %}
         <li data-bind="css: { active: 1 === {{n}} }, using: settings.plugins.octorelay.r{{n}}">
-            <a href="#relay_settings_{{n}}" data-bind="text: label_text() || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_{{n}}"
+                data-bind="text: label_text() || '{{ _('Relay') }} {{n}}'"
+                data-toggle="tab"
+            ></a>
         </li>
         {% endfor %}
     </ul>
 
-
     <div class="tab-content">
         {% for n in range(1,9) %}
-        <div id="relay_settings_{{n}}" class="tab-pane" data-bind="css: { active: 1 === {{n}} }, using: settings.plugins.octorelay.r{{n}}">
+        <div
+            id="relay_settings_{{n}}"
+            class="tab-pane"
+            data-bind="css: { active: 1 === {{n}} }, using: settings.plugins.octorelay.r{{n}}"
+        >
+
             <div class="control-group">
                 <label class="control-label">{{ _('Active') }}</label>
                 <div class="controls">
                     <div class="btn-group">
                         {% for value, option in plugin_octorelay_boolean.items() %}
-                        <label class="btn" data-bind="css: { 'active btn-{{option.color}}': active() === {{value}}, 'btn-default': active() !== {{value}} }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { 'active btn-{{option.color}}': active() === {{value}}, 'btn-default': active() !== {{value}} }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: {{value}}, checked: active"
+                            />
                             {{ _(option.caption) }}
                         </label>
                         {% endfor %}
@@ -29,6 +44,7 @@
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">{{ _('Label') }}</label>
@@ -36,19 +52,35 @@
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">{{ _('GPIO Number') }}</label>
                     <div class="controls">
-                        <input id="relay_pin-input{{n}}" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input{{n}}"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">{{ _('Inverted output') }}</label>
                     <div class="controls">
                         <div class="btn-group">
                             {% for value, option in plugin_octorelay_boolean.items() %}
-                            <label class="btn" data-bind="css: { 'active btn-{{option.color}}': inverted_output() === {{value}}, 'btn-default': inverted_output() !== {{value}} }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { 'active btn-{{option.color}}': inverted_output() === {{value}}, 'btn-default': inverted_output() !== {{value}} }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: {{value}}, checked: inverted_output"
+                                />
                                 {{ _(option.caption) }}
                             </label>
                             {% endfor %}
@@ -65,8 +97,8 @@
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_{{state}}">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_{{state}}"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_{{state}}"
                         ></div>
                     </div>
                 </div>
@@ -77,8 +109,15 @@
                     <div class="controls">
                         <div class="btn-group">
                             {% for value, option in plugin_octorelay_boolean.items() %}
-                            <label class="btn" data-bind="css: { 'active btn-{{option.color}}': confirm_off() === {{value}}, 'btn-default': confirm_off() !== {{value}} }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { 'active btn-{{option.color}}': confirm_off() === {{value}}, 'btn-default': confirm_off() !== {{value}} }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: {{value}}, checked: confirm_off"
+                                />
                                 {{ _(option.caption) }}
                             </label>
                             {% endfor %}
@@ -92,8 +131,14 @@
                     <div class="controls">
                         <div class="btn-group">
                             {% for value, state in plugin_octorelay_tristate.items() %}
-                            <label class="btn" data-bind="css: { 'active btn-{{state.color}}': state() === {{value}}, 'btn-default': state() !== {{value}} }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { 'active btn-{{state.color}}': state() === {{value}}, 'btn-default': state() !== {{value}} }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: {{value}}, checked: state"
+                                />
                                 {{ _(state.caption) }}
                             </label>
                             {% endfor %}
@@ -120,5 +165,4 @@
         </div>
         {% endfor %}
     </div>
-
 </form>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -42,38 +42,29 @@
                         </label>
                     </div>
                 </div>
+
+                {% for state in ["on", "off"] %}
                 <div class="control-group">
-                    <label class="control-label">{{ _('OS Command ON') }}</label>
+                    <label class="control-label">{{ _('OS Command') }} {{ _(state.upper()) }}</label>
                     <div class="controls">
-                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                        <input type="text" class="input-large" data-bind="value: cmd_{{state}}">
                     </div>
                 </div>
+                {% endfor %}
+
+                {% for state in ["on", "off"] %}
                 <div class="control-group">
-                    <label class="control-label">{{ _('OS Command OFF') }}</label>
+                    <label class="control-label">{{ _('Icon') }} {{ _(state.upper()) }}</label>
                     <div class="controls">
-                        <input type="text" class="input-large" data-bind="value: cmd_off">
-                    </div>
-                </div>
-                <div class="control-group">
-                    <label class="control-label">{{ _('Icon ON') }}</label>
-                    <div class="controls">
-                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <input type="text" class="input-large" data-bind="value: icon_{{state}}">
                         <div
-                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                            data-bind="html: icon_on"
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_{{state}}"
                         ></div>
                     </div>
                 </div>
-                <div class="control-group">
-                    <label class="control-label">{{ _('Icon OFF') }}</label>
-                    <div class="controls">
-                        <input type="text" class="input-large" data-bind="value: icon_off">
-                        <div
-                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                            data-bind="html: icon_off"
-                        ></div>
-                    </div>
-                </div>
+                {% endfor %}
+
                 <div class="control-group">
                     <label class="control-label">{{ _('Confirmation') }}</label>
                     <div class="controls">

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -70,30 +70,21 @@
             </div>
 
 
-            <label class="control-label">{{ _('Startup') }}</label>
+            {% for event in ["STARTUP", "PRINTING_STARTED", "PRINTING_STOPPED"] %}
+            <label class="control-label">{{ _(event) }}</label>
             <div class="controls">
                 <div class="btn-group">
                     {% for value in ["true", "false", "null"] %}
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state() === {{value}} }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: settings.plugins.octorelay.r{{n}}.rules.STARTUP.state" />
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === {{value}} }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state" />
                         {{"ON" if value == "true" else "OFF" if value == "false" else "skip"}}
                     </label>
                     {% endfor %}
                 </div>
             </div>
+            {% endfor %}
 
 
-            <label class="control-label">{{ _('Auto ON/OFF') }}</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.auto_on_before_print">
-                    {{ _('ON before printing') }}
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.auto_off_after_print">
-                    {{ _('OFF after printing') }}
-                </label>
-            </div>
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r{{n}}.auto_off_after_print">
                 {{ _('Delay') }}
             </label>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -99,7 +99,7 @@
                             {% endfor %}
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">{{ _('Delay') }}</span>
+                            <span class="add-on">{{ _('delay') }}</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">{{ _('s') }}</span>
                         </div>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -4,7 +4,7 @@
     <ul class="nav nav-pills">
         {% for n in range(1,9) %}
         <li data-bind="css: { active: 1 === {{n}} }">
-            <a href="#relay{{n}}" data-bind="text: settings.plugins.octorelay.r{{n}}.label_text() || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
+            <a href="#relay_settings_{{n}}" data-bind="text: settings.plugins.octorelay.r{{n}}.label_text() || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
         </li>
         {% endfor %}
     </ul>
@@ -12,7 +12,7 @@
 
     <div class="tab-content">
         {% for n in range(1,9) %}
-        <div id="relay{{n}}" class="tab-pane" data-bind="css: { active: 1 === {{n}} }">
+        <div id="relay_settings_{{n}}" class="tab-pane" data-bind="css: { active: 1 === {{n}} }">
             <div class="control-group">
                 <label class="control-label">{{ _('Relay') }} {{n}}</label>
                 <div class="controls">

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -1,110 +1,125 @@
 <form class="form-horizontal">
     <h3>OctoRelay Settings</h3>
-    {% for n in range(1,9) %}
-    <div class="control-group">
-        <label class="control-label">{{ _('Relay') }} {{n}}</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.active">
-                {{ _('Active') }}
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r{{n}}.active, text: settings.plugins.octorelay.r{{n}}.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-    </div>
-    <div data-bind="visible: settings.plugins.octorelay.r{{n}}.active">
-        <div class="control-group">
-            <label class="control-label">{{ _('Label') }}</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.label_text">
-                </label>
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">{{ _('GPIO Number') }}</label>
-            <div class="controls">
-                <input id="relay_pin-input{{n}}" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.inverted_output">
-                    {{ _('Inverted output') }}
-                </label>
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">{{ _('OS Command ON') }}</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_on">
-                </label>
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">{{ _('OS Command OFF') }}</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_off">
-                </label>
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">{{ _('Icon ON') }}</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r{{n}}.icon_on"
-                    ></div>
-                </label>
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">{{ _('Icon OFF') }}</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r{{n}}.icon_off"
-                    ></div>
-                </label>
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">{{ _('Confirmation') }}</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.confirm_off">
-                    {{ _('Warning on turning OFF') }}
-                </label>
-            </div>
-        </div>
+    
+    <ul class="nav nav-pills">
+        {% for n in range(1,9) %}
+        <li data-bind="css: { active: 1 === {{n}} }">
+            <a href="#relay{{n}}" data-bind="text: settings.plugins.octorelay.r{{n}}.label_text || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
+        </li>
+        {% endfor %}
+    </ul>
 
-        {% for event, label in plugin_octorelay_events.items() %}
-        <div class="control-group">
-            <label class="control-label">{{ _(label) }}</label>
-            <div class="controls">
-                <div class="btn-group">
-                    {% for value, caption in plugin_octorelay_tristate.items() %}
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === {{value}} }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state" />
-                        {{ _(caption) }}
+
+    <div class="tab-content">
+        {% for n in range(1,9) %}
+        <div id="relay{{n}}" class="tab-pane" data-bind="css: { active: 1 === {{n}} }">
+            <div class="control-group">
+                <label class="control-label">{{ _('Relay') }} {{n}}</label>
+                <div class="controls">
+                    <label class="checkbox">
+                        <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.active">
+                        {{ _('Active') }}
+                        <span
+                                class="help-inline"
+                                data-bind="hidden: settings.plugins.octorelay.r{{n}}.active, text: settings.plugins.octorelay.r{{n}}.label_text"
+                                style="line-height: initial; vertical-align: unset;"
+                        ></span>
                     </label>
-                    {% endfor %}
                 </div>
-                <div class="input-prepend input-append" data-bind="hidden: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === null">
-                    <span class="add-on">{{ _('Delay') }}</span>
-                    <input type="number" min="0" max="86400" class="input-mini" data-bind="value: settings.plugins.octorelay.r{{n}}.rules.{{event}}.delay">
-                    <span class="add-on">{{ _('s') }}</span>
+            </div>
+            <div data-bind="visible: settings.plugins.octorelay.r{{n}}.active">
+                <div class="control-group">
+                    <label class="control-label">{{ _('Label') }}</label>
+                    <div class="controls">
+                        <label class="text">
+                            <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.label_text">
+                        </label>
+                    </div>
                 </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('GPIO Number') }}</label>
+                    <div class="controls">
+                        <input id="relay_pin-input{{n}}" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.relay_pin">
+                        <label class="checkbox">
+                            <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.inverted_output">
+                            {{ _('Inverted output') }}
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('OS Command ON') }}</label>
+                    <div class="controls">
+                        <label class="text">
+                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_on">
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('OS Command OFF') }}</label>
+                    <div class="controls">
+                        <label class="text">
+                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_off">
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('Icon ON') }}</label>
+                    <div class="controls">
+                        <label class="text">
+                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.icon_on">
+                            <div
+                                    style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
+                                    data-bind="html: settings.plugins.octorelay.r{{n}}.icon_on"
+                            ></div>
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('Icon OFF') }}</label>
+                    <div class="controls">
+                        <label class="text">
+                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.icon_off">
+                            <div
+                                    style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
+                                    data-bind="html: settings.plugins.octorelay.r{{n}}.icon_off"
+                            ></div>
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('Confirmation') }}</label>
+                    <div class="controls">
+                        <label class="checkbox">
+                            <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.confirm_off">
+                            {{ _('Warning on turning OFF') }}
+                        </label>
+                    </div>
+                </div>
+
+                {% for event, label in plugin_octorelay_events.items() %}
+                <div class="control-group">
+                    <label class="control-label">{{ _(label) }}</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            {% for value, caption in plugin_octorelay_tristate.items() %}
+                            <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === {{value}} }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state" />
+                                {{ _(caption) }}
+                            </label>
+                            {% endfor %}
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === null">
+                            <span class="add-on">{{ _('Delay') }}</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: settings.plugins.octorelay.r{{n}}.rules.{{event}}.delay">
+                            <span class="add-on">{{ _('s') }}</span>
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+
             </div>
         </div>
         {% endfor %}
-
     </div>
-    {% endfor %}
+
 </form>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -1,10 +1,10 @@
 <form class="form-horizontal">
     <h3>OctoRelay Settings</h3>
-    
+
     <ul class="nav nav-pills">
         {% for n in range(1,9) %}
         <li data-bind="css: { active: 1 === {{n}} }">
-            <a href="#relay{{n}}" data-bind="text: settings.plugins.octorelay.r{{n}}.label_text || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
+            <a href="#relay{{n}}" data-bind="text: settings.plugins.octorelay.r{{n}}.label_text() || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
         </li>
         {% endfor %}
     </ul>

--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -3,8 +3,8 @@
 
     <ul class="nav nav-pills">
         {% for n in range(1,9) %}
-        <li data-bind="css: { active: 1 === {{n}} }">
-            <a href="#relay_settings_{{n}}" data-bind="text: settings.plugins.octorelay.r{{n}}.label_text() || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
+        <li data-bind="css: { active: 1 === {{n}} }, using: settings.plugins.octorelay.r{{n}}">
+            <a href="#relay_settings_{{n}}" data-bind="text: label_text() || '{{ _('Relay') }} {{n}}'" data-toggle="tab"></a>
         </li>
         {% endfor %}
     </ul>
@@ -12,34 +12,34 @@
 
     <div class="tab-content">
         {% for n in range(1,9) %}
-        <div id="relay_settings_{{n}}" class="tab-pane" data-bind="css: { active: 1 === {{n}} }">
+        <div id="relay_settings_{{n}}" class="tab-pane" data-bind="css: { active: 1 === {{n}} }, using: settings.plugins.octorelay.r{{n}}">
             <div class="control-group">
                 <label class="control-label">{{ _('Relay') }} {{n}}</label>
                 <div class="controls">
                     <label class="checkbox">
-                        <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.active">
+                        <input type="checkbox" data-bind="checked: active">
                         {{ _('Active') }}
                     </label>
-                    <span class="help-block" data-bind="hidden: settings.plugins.octorelay.r{{n}}.active">
+                    <span class="help-block" data-bind="hidden: active">
                         {{ _('All operations on this relay are disabled') }}
                     </span>
                 </div>
             </div>
-            <div data-bind="visible: settings.plugins.octorelay.r{{n}}.active">
+            <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">{{ _('Label') }}</label>
                     <div class="controls">
                         <label class="text">
-                            <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.label_text">
+                            <input type="text" class="input-small" data-bind="value: label_text">
                         </label>
                     </div>
                 </div>
                 <div class="control-group">
                     <label class="control-label">{{ _('GPIO Number') }}</label>
                     <div class="controls">
-                        <input id="relay_pin-input{{n}}" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r{{n}}.relay_pin">
+                        <input id="relay_pin-input{{n}}" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
                         <label class="checkbox">
-                            <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.inverted_output">
+                            <input type="checkbox" data-bind="checked: inverted_output">
                             {{ _('Inverted output') }}
                         </label>
                     </div>
@@ -48,7 +48,7 @@
                     <label class="control-label">{{ _('OS Command ON') }}</label>
                     <div class="controls">
                         <label class="text">
-                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_on">
+                            <input type="text" class="input-large" data-bind="value: cmd_on">
                         </label>
                     </div>
                 </div>
@@ -56,7 +56,7 @@
                     <label class="control-label">{{ _('OS Command OFF') }}</label>
                     <div class="controls">
                         <label class="text">
-                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.cmd_off">
+                            <input type="text" class="input-large" data-bind="value: cmd_off">
                         </label>
                     </div>
                 </div>
@@ -64,10 +64,10 @@
                     <label class="control-label">{{ _('Icon ON') }}</label>
                     <div class="controls">
                         <label class="text">
-                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.icon_on">
+                            <input type="text" class="input-large" data-bind="value: icon_on">
                             <div
                                     style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                                    data-bind="html: settings.plugins.octorelay.r{{n}}.icon_on"
+                                    data-bind="html: icon_on"
                             ></div>
                         </label>
                     </div>
@@ -76,10 +76,10 @@
                     <label class="control-label">{{ _('Icon OFF') }}</label>
                     <div class="controls">
                         <label class="text">
-                            <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r{{n}}.icon_off">
+                            <input type="text" class="input-large" data-bind="value: icon_off">
                             <div
                                     style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                                    data-bind="html: settings.plugins.octorelay.r{{n}}.icon_off"
+                                    data-bind="html: icon_off"
                             ></div>
                         </label>
                     </div>
@@ -88,7 +88,7 @@
                     <label class="control-label">{{ _('Confirmation') }}</label>
                     <div class="controls">
                         <label class="checkbox">
-                            <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r{{n}}.confirm_off">
+                            <input type="checkbox" data-bind="checked: confirm_off">
                             {{ _('Warning on turning OFF') }}
                         </label>
                     </div>
@@ -100,15 +100,15 @@
                     <div class="controls">
                         <div class="btn-group">
                             {% for value, caption in plugin_octorelay_tristate.items() %}
-                            <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === {{value}} }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state" />
+                            <label class="btn btn-default" data-bind="css: { active: rules.{{event}}.state() === {{value}} }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: {{value}}, checked: rules.{{event}}.state" />
                                 {{ _(caption) }}
                             </label>
                             {% endfor %}
                         </div>
-                        <div class="input-prepend input-append" data-bind="hidden: settings.plugins.octorelay.r{{n}}.rules.{{event}}.state() === null">
+                        <div class="input-prepend input-append" data-bind="hidden: rules.{{event}}.state() === null">
                             <span class="add-on">{{ _('Delay') }}</span>
-                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: settings.plugins.octorelay.r{{n}}.rules.{{event}}.delay">
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: rules.{{event}}.delay">
                             <span class="add-on">{{ _('s') }}</span>
                         </div>
                     </div>

--- a/tests/snapshots/snap_test_templates.py
+++ b/tests/snapshots/snap_test_templates.py
@@ -57,1229 +57,1710 @@ snapshots['TestTemplates::test_templates octorelay_navbar.jinja2'] = '''
 
 snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form class="form-horizontal">
     <h3>OctoRelay Settings</h3>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 1</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r1.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r1.active, text: settings.plugins.octorelay.r1.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r1.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r1.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input1" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r1.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r1.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r1.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r1.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r1.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r1.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r1.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r1.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r1.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
+
+    <ul class="nav nav-pills">
+        
+        <li data-bind="css: { active: 1 === 1 }, using: settings.plugins.octorelay.r1">
+            <a href="#relay_settings_1" data-bind="text: label_text() || \'Relay 1\'" data-toggle="tab"></a>
+        </li>
+        
+        <li data-bind="css: { active: 1 === 2 }, using: settings.plugins.octorelay.r2">
+            <a href="#relay_settings_2" data-bind="text: label_text() || \'Relay 2\'" data-toggle="tab"></a>
+        </li>
+        
+        <li data-bind="css: { active: 1 === 3 }, using: settings.plugins.octorelay.r3">
+            <a href="#relay_settings_3" data-bind="text: label_text() || \'Relay 3\'" data-toggle="tab"></a>
+        </li>
+        
+        <li data-bind="css: { active: 1 === 4 }, using: settings.plugins.octorelay.r4">
+            <a href="#relay_settings_4" data-bind="text: label_text() || \'Relay 4\'" data-toggle="tab"></a>
+        </li>
+        
+        <li data-bind="css: { active: 1 === 5 }, using: settings.plugins.octorelay.r5">
+            <a href="#relay_settings_5" data-bind="text: label_text() || \'Relay 5\'" data-toggle="tab"></a>
+        </li>
+        
+        <li data-bind="css: { active: 1 === 6 }, using: settings.plugins.octorelay.r6">
+            <a href="#relay_settings_6" data-bind="text: label_text() || \'Relay 6\'" data-toggle="tab"></a>
+        </li>
+        
+        <li data-bind="css: { active: 1 === 7 }, using: settings.plugins.octorelay.r7">
+            <a href="#relay_settings_7" data-bind="text: label_text() || \'Relay 7\'" data-toggle="tab"></a>
+        </li>
+        
+        <li data-bind="css: { active: 1 === 8 }, using: settings.plugins.octorelay.r8">
+            <a href="#relay_settings_8" data-bind="text: label_text() || \'Relay 8\'" data-toggle="tab"></a>
+        </li>
+        
+    </ul>
 
 
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r1.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r1.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r1.auto_off_delay">
-                        <span class="add-on">seconds</span>
+    <div class="tab-content">
+        
+        <div id="relay_settings_1" class="tab-pane" data-bind="css: { active: 1 === 1 }, using: settings.plugins.octorelay.r1">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 2</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r2.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r2.active, text: settings.plugins.octorelay.r2.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r2.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r2.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input2" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r2.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r2.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r2.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r2.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r2.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r2.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r2.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r2.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r2.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
-
-
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
                 </div>
             </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r2.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r2.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r2.auto_off_delay">
-                        <span class="add-on">seconds</span>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 3</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r3.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r3.active, text: settings.plugins.octorelay.r3.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r3.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r3.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input3" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r3.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r3.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r3.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r3.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r3.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r3.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r3.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r3.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r3.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
-
-
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
                 </div>
-            </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r3.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r3.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r3.auto_off_delay">
-                        <span class="add-on">seconds</span>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input1" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 4</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r4.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r4.active, text: settings.plugins.octorelay.r4.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r4.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r4.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input4" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r4.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r4.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r4.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r4.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r4.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r4.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r4.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r4.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r4.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
-
-
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
                 </div>
-            </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r4.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r4.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r4.auto_off_delay">
-                        <span class="add-on">seconds</span>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 5</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r5.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r5.active, text: settings.plugins.octorelay.r5.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r5.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r5.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input5" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r5.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r5.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r5.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r5.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r5.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r5.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r5.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r5.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r5.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
-
-
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
                 </div>
-            </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
 
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r5.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r5.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r5.auto_off_delay">
-                        <span class="add-on">seconds</span>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 6</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r6.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r6.active, text: settings.plugins.octorelay.r6.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r6.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r6.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input6" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r6.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r6.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r6.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r6.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r6.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r6.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r6.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r6.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r6.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
-
-
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
                 </div>
-            </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r6.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r6.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r6.auto_off_delay">
-                        <span class="add-on">seconds</span>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 7</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r7.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r7.active, text: settings.plugins.octorelay.r7.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r7.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r7.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input7" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r7.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r7.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r7.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r7.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r7.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r7.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r7.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r7.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r7.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
-
-
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
                 </div>
-            </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
+                
 
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r7.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r7.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r7.auto_off_delay">
-                        <span class="add-on">seconds</span>
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    
-    <div class="control-group">
-        <label class="control-label">Relay 8</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r8.active">
-                Active
-                <span
-                    class="help-inline"
-                    data-bind="hidden: settings.plugins.octorelay.r8.active, text: settings.plugins.octorelay.r8.label_text"
-                    style="line-height: initial; vertical-align: unset;"
-                ></span>
-            </label>
-        </div>
-        <div data-bind="visible: settings.plugins.octorelay.r8.active">
-            <label class="control-label">Label</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-small" data-bind="value: settings.plugins.octorelay.r8.label_text">
-                </label>
-            </div>
-            <label class="control-label">GPIO Number</label>
-            <div class="controls">
-                <input id="relay_pin-input8" type="number" min="1" max="27" class="input-small" data-bind="value: settings.plugins.octorelay.r8.relay_pin">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r8.inverted_output">
-                    Inverted output
-                </label>
-            </div>
-            <label class="control-label">OS Command ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r8.cmd_on">
-                </label>
-            </div>
-            <label class="control-label">OS Command OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r8.cmd_off">
-                </label>
-            </div>
-            <label class="control-label">Icon ON</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r8.icon_on">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r8.icon_on"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Icon OFF</label>
-            <div class="controls">
-                <label class="text">
-                    <input type="text" class="input-large" data-bind="value: settings.plugins.octorelay.r8.icon_off">
-                    <div
-                        style="display: inline-block; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.3em;"
-                        data-bind="html: settings.plugins.octorelay.r8.icon_off"
-                    ></div>
-                </label>
-            </div>
-            <label class="control-label">Confirmation</label>
-            <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r8.confirm_off">
-                    Warning on turning OFF
-                </label>
-            </div>
-
-
-            
-            <label class="control-label">on Startup</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
-                        skip
-                    </label>
-                    
                 </div>
-            </div>
-            
-            <label class="control-label">on Printing Started</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
-            <label class="control-label">on Printing Stopped</label>
-            <div class="controls">
-                <div class="btn-group">
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state() === true }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state" />
-                        ON
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state() === false }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state" />
-                        OFF
-                    </label>
-                    
-                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state() === null }">
-                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state" />
-                        skip
-                    </label>
-                    
-                </div>
-            </div>
-            
 
-
-            <label class="control-label" data-bind="visible: settings.plugins.octorelay.r8.auto_off_after_print">
-                Delay
-            </label>
-            <div class="controls" data-bind="visible: settings.plugins.octorelay.r8.auto_off_after_print">
-                <label class="text">
-                    <div class="input-append">
-                        <input type="number" min="0" max="86400" class="input-small" data-bind="value: settings.plugins.octorelay.r8.auto_off_delay">
-                        <span class="add-on">seconds</span>
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
                     </div>
-                    <span class="help-block">The delay to turn the relay OFF. For example for a fan, that should run a little longer after the print.</span>
-                </label>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
             </div>
         </div>
+        
+        <div id="relay_settings_2" class="tab-pane" data-bind="css: { active: 1 === 2 }, using: settings.plugins.octorelay.r2">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
+                    </div>
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input2" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
+                    </div>
+                </div>
+
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
+                    </div>
+                </div>
+                
+
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
+            </div>
+        </div>
+        
+        <div id="relay_settings_3" class="tab-pane" data-bind="css: { active: 1 === 3 }, using: settings.plugins.octorelay.r3">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
+                    </div>
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input3" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
+                    </div>
+                </div>
+
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
+                    </div>
+                </div>
+                
+
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
+            </div>
+        </div>
+        
+        <div id="relay_settings_4" class="tab-pane" data-bind="css: { active: 1 === 4 }, using: settings.plugins.octorelay.r4">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
+                    </div>
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input4" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
+                    </div>
+                </div>
+
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
+                    </div>
+                </div>
+                
+
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
+            </div>
+        </div>
+        
+        <div id="relay_settings_5" class="tab-pane" data-bind="css: { active: 1 === 5 }, using: settings.plugins.octorelay.r5">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
+                    </div>
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input5" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
+                    </div>
+                </div>
+
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
+                    </div>
+                </div>
+                
+
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
+            </div>
+        </div>
+        
+        <div id="relay_settings_6" class="tab-pane" data-bind="css: { active: 1 === 6 }, using: settings.plugins.octorelay.r6">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
+                    </div>
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input6" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
+                    </div>
+                </div>
+
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
+                    </div>
+                </div>
+                
+
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
+            </div>
+        </div>
+        
+        <div id="relay_settings_7" class="tab-pane" data-bind="css: { active: 1 === 7 }, using: settings.plugins.octorelay.r7">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
+                    </div>
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input7" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
+                    </div>
+                </div>
+
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
+                    </div>
+                </div>
+                
+
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
+            </div>
+        </div>
+        
+        <div id="relay_settings_8" class="tab-pane" data-bind="css: { active: 1 === 8 }, using: settings.plugins.octorelay.r8">
+            <div class="control-group">
+                <label class="control-label">Active</label>
+                <div class="controls">
+                    <div class="btn-group">
+                        
+                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                            YES
+                        </label>
+                        
+                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
+                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                            NO
+                        </label>
+                        
+                    </div>
+                    <span class="help-block" data-bind="hidden: active">
+                        All operations on this relay are disabled
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: active">
+                <div class="control-group">
+                    <label class="control-label">Label</label>
+                    <div class="controls">
+                        <input type="text" class="input-small" data-bind="value: label_text">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">GPIO Number</label>
+                    <div class="controls">
+                        <input id="relay_pin-input8" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">Inverted output</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                                NO
+                            </label>
+                            
+                        </div>
+                        <span class="help-block">
+                            For normally closed relays: the electrical circuit is closed without applying current and the relay connects the power to the load.
+                        </span>
+                    </div>
+                </div>
+
+                
+                <div class="control-group">
+                    <label class="control-label">Icon ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_on">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_on"
+                        ></div>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">Icon OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: icon_off">
+                        <div
+                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                                data-bind="html: icon_off"
+                        ></div>
+                    </div>
+                </div>
+                
+
+                <div class="control-group">
+                    <label class="control-label">Warn when turning OFF</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                                YES
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                                NO
+                            </label>
+                            
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="control-group" data-bind="using: rules.STARTUP">
+                    <label class="control-label">on Startup</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STARTED">
+                    <label class="control-label">on Printing Started</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="control-group" data-bind="using: rules.PRINTING_STOPPED">
+                    <label class="control-label">on Printing Stopped</label>
+                    <div class="controls">
+                        <div class="btn-group">
+                            
+                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                                ON
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
+                                OFF
+                            </label>
+                            
+                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
+                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
+                                skip
+                            </label>
+                            
+                        </div>
+                        <div class="input-prepend input-append" data-bind="hidden: state() === null">
+                            <span class="add-on">Delay</span>
+                            <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
+                            <span class="add-on">s</span>
+                        </div>
+                    </div>
+                </div>
+                
+
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command ON</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_on">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <label class="control-label">OS Command OFF</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" data-bind="value: cmd_off">
+                    </div>
+                </div>
+                
+
+            </div>
+        </div>
+        
     </div>
-    
+
 </form>'''

--- a/tests/snapshots/snap_test_templates.py
+++ b/tests/snapshots/snap_test_templates.py
@@ -127,36 +127,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r1.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r1.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r1.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r1.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r1.auto_off_after_print">
                 Delay
             </label>
@@ -241,36 +280,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r2.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r2.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r2.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r2.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r2.auto_off_after_print">
                 Delay
             </label>
@@ -355,36 +433,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r3.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r3.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r3.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r3.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r3.auto_off_after_print">
                 Delay
             </label>
@@ -469,36 +586,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r4.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r4.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r4.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r4.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r4.auto_off_after_print">
                 Delay
             </label>
@@ -583,36 +739,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r5.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r5.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r5.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r5.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r5.auto_off_after_print">
                 Delay
             </label>
@@ -697,36 +892,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r6.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r6.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r6.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r6.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r6.auto_off_after_print">
                 Delay
             </label>
@@ -811,36 +1045,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r7.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r7.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r7.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r7.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r7.auto_off_after_print">
                 Delay
             </label>
@@ -925,36 +1198,75 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
 
 
-            <label class="control-label">Startup</label>
+            
+            <label class="control-label">STARTUP</label>
             <div class="controls">
                 <div class="btn-group">
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
                         ON
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === false }">
                         <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
                         OFF
                     </label>
+                    
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === null }">
                         <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
-                        no action
+                        skip
                     </label>
+                    
                 </div>
             </div>
-
-
-            <label class="control-label">Auto ON/OFF</label>
+            
+            <label class="control-label">PRINTING_STARTED</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r8.auto_on_before_print">
-                    ON before printing
-                </label>
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r8.auto_off_after_print">
-                    OFF after printing
-                </label>
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r8.rules.PRINTING_STARTED.state" />
+                        skip
+                    </label>
+                    
+                </div>
             </div>
+            
+            <label class="control-label">PRINTING_STOPPED</label>
+            <div class="controls">
+                <div class="btn-group">
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state" />
+                        ON
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state" />
+                        OFF
+                    </label>
+                    
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r8.rules.PRINTING_STOPPED.state" />
+                        skip
+                    </label>
+                    
+                </div>
+            </div>
+            
+
+
             <label class="control-label" data-bind="visible: settings.plugins.octorelay.r8.auto_off_after_print">
                 Delay
             </label>

--- a/tests/snapshots/snap_test_templates.py
+++ b/tests/snapshots/snap_test_templates.py
@@ -129,7 +129,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
                         ON
@@ -243,7 +243,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
                         ON
@@ -357,7 +357,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
                         ON
@@ -471,7 +471,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
                         ON
@@ -585,7 +585,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
                         ON
@@ -699,7 +699,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
                         ON
@@ -813,7 +813,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
                         ON
@@ -927,7 +927,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
             <label class="control-label">Startup</label>
             <div class="controls">
-                <div class="btn-group" >
+                <div class="btn-group">
                     <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === true }">
                         <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
                         ON

--- a/tests/snapshots/snap_test_templates.py
+++ b/tests/snapshots/snap_test_templates.py
@@ -125,12 +125,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r1.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r1.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r1.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r1.auto_on_before_print">
                     ON before printing
@@ -222,12 +239,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r2.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r2.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r2.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r2.auto_on_before_print">
                     ON before printing
@@ -319,12 +353,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r3.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r3.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r3.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r3.auto_on_before_print">
                     ON before printing
@@ -416,12 +467,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r4.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r4.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r4.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r4.auto_on_before_print">
                     ON before printing
@@ -513,12 +581,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r5.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r5.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r5.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r5.auto_on_before_print">
                     ON before printing
@@ -610,12 +695,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r6.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r6.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r6.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r6.auto_on_before_print">
                     ON before printing
@@ -707,12 +809,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r7.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r7.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r7.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r7.auto_on_before_print">
                     ON before printing
@@ -804,12 +923,29 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     Warning on turning OFF
                 </label>
             </div>
+
+
+            <label class="control-label">Startup</label>
+            <div class="controls">
+                <div class="btn-group" >
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === true }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: true, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
+                        ON
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === false }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: false, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
+                        OFF
+                    </label>
+                    <label class="btn btn-default" data-bind="css: { active: settings.plugins.octorelay.r8.rules.STARTUP.state() === null }">
+                        <input type="radio" style="display:none" data-bind="checkedValue: null, checked: settings.plugins.octorelay.r8.rules.STARTUP.state" />
+                        no action
+                    </label>
+                </div>
+            </div>
+
+
             <label class="control-label">Auto ON/OFF</label>
             <div class="controls">
-                <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r8.initial_value">
-                    ON initially on boot
-                </label>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.octorelay.r8.auto_on_before_print">
                     ON before printing

--- a/tests/snapshots/snap_test_templates.py
+++ b/tests/snapshots/snap_test_templates.py
@@ -128,7 +128,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -150,7 +150,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -172,7 +172,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -281,7 +281,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -303,7 +303,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -325,7 +325,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -434,7 +434,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -456,7 +456,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -478,7 +478,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -587,7 +587,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -609,7 +609,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -631,7 +631,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -740,7 +740,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -762,7 +762,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -784,7 +784,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -893,7 +893,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -915,7 +915,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -937,7 +937,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -1046,7 +1046,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -1068,7 +1068,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -1090,7 +1090,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -1199,7 +1199,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
 
 
             
-            <label class="control-label">STARTUP</label>
+            <label class="control-label">on Startup</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -1221,7 +1221,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STARTED</label>
+            <label class="control-label">on Printing Started</label>
             <div class="controls">
                 <div class="btn-group">
                     
@@ -1243,7 +1243,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                 </div>
             </div>
             
-            <label class="control-label">PRINTING_STOPPED</label>
+            <label class="control-label">on Printing Stopped</label>
             <div class="controls">
                 <div class="btn-group">
                     

--- a/tests/snapshots/snap_test_templates.py
+++ b/tests/snapshots/snap_test_templates.py
@@ -61,55 +61,105 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
     <ul class="nav nav-pills">
         
         <li data-bind="css: { active: 1 === 1 }, using: settings.plugins.octorelay.r1">
-            <a href="#relay_settings_1" data-bind="text: label_text() || \'Relay 1\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_1"
+                data-bind="text: label_text() || \'Relay 1\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
         <li data-bind="css: { active: 1 === 2 }, using: settings.plugins.octorelay.r2">
-            <a href="#relay_settings_2" data-bind="text: label_text() || \'Relay 2\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_2"
+                data-bind="text: label_text() || \'Relay 2\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
         <li data-bind="css: { active: 1 === 3 }, using: settings.plugins.octorelay.r3">
-            <a href="#relay_settings_3" data-bind="text: label_text() || \'Relay 3\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_3"
+                data-bind="text: label_text() || \'Relay 3\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
         <li data-bind="css: { active: 1 === 4 }, using: settings.plugins.octorelay.r4">
-            <a href="#relay_settings_4" data-bind="text: label_text() || \'Relay 4\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_4"
+                data-bind="text: label_text() || \'Relay 4\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
         <li data-bind="css: { active: 1 === 5 }, using: settings.plugins.octorelay.r5">
-            <a href="#relay_settings_5" data-bind="text: label_text() || \'Relay 5\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_5"
+                data-bind="text: label_text() || \'Relay 5\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
         <li data-bind="css: { active: 1 === 6 }, using: settings.plugins.octorelay.r6">
-            <a href="#relay_settings_6" data-bind="text: label_text() || \'Relay 6\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_6"
+                data-bind="text: label_text() || \'Relay 6\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
         <li data-bind="css: { active: 1 === 7 }, using: settings.plugins.octorelay.r7">
-            <a href="#relay_settings_7" data-bind="text: label_text() || \'Relay 7\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_7"
+                data-bind="text: label_text() || \'Relay 7\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
         <li data-bind="css: { active: 1 === 8 }, using: settings.plugins.octorelay.r8">
-            <a href="#relay_settings_8" data-bind="text: label_text() || \'Relay 8\'" data-toggle="tab"></a>
+            <a
+                href="#relay_settings_8"
+                data-bind="text: label_text() || \'Relay 8\'"
+                data-toggle="tab"
+            ></a>
         </li>
         
     </ul>
 
-
     <div class="tab-content">
         
-        <div id="relay_settings_1" class="tab-pane" data-bind="css: { active: 1 === 1 }, using: settings.plugins.octorelay.r1">
+        <div
+            id="relay_settings_1"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 1 }, using: settings.plugins.octorelay.r1"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -119,6 +169,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -126,24 +177,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input1" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input1"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -160,8 +234,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -171,8 +245,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -183,13 +257,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -203,24 +291,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -232,24 +338,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -261,24 +385,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -305,19 +447,38 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
         </div>
         
-        <div id="relay_settings_2" class="tab-pane" data-bind="css: { active: 1 === 2 }, using: settings.plugins.octorelay.r2">
+        <div
+            id="relay_settings_2"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 2 }, using: settings.plugins.octorelay.r2"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -327,6 +488,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -334,24 +496,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input2" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input2"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -368,8 +553,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -379,8 +564,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -391,13 +576,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -411,24 +610,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -440,24 +657,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -469,24 +704,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -513,19 +766,38 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
         </div>
         
-        <div id="relay_settings_3" class="tab-pane" data-bind="css: { active: 1 === 3 }, using: settings.plugins.octorelay.r3">
+        <div
+            id="relay_settings_3"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 3 }, using: settings.plugins.octorelay.r3"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -535,6 +807,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -542,24 +815,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input3" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input3"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -576,8 +872,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -587,8 +883,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -599,13 +895,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -619,24 +929,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -648,24 +976,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -677,24 +1023,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -721,19 +1085,38 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
         </div>
         
-        <div id="relay_settings_4" class="tab-pane" data-bind="css: { active: 1 === 4 }, using: settings.plugins.octorelay.r4">
+        <div
+            id="relay_settings_4"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 4 }, using: settings.plugins.octorelay.r4"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -743,6 +1126,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -750,24 +1134,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input4" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input4"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -784,8 +1191,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -795,8 +1202,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -807,13 +1214,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -827,24 +1248,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -856,24 +1295,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -885,24 +1342,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -929,19 +1404,38 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
         </div>
         
-        <div id="relay_settings_5" class="tab-pane" data-bind="css: { active: 1 === 5 }, using: settings.plugins.octorelay.r5">
+        <div
+            id="relay_settings_5"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 5 }, using: settings.plugins.octorelay.r5"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -951,6 +1445,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -958,24 +1453,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input5" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input5"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -992,8 +1510,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -1003,8 +1521,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -1015,13 +1533,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -1035,24 +1567,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1064,24 +1614,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1093,24 +1661,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1137,19 +1723,38 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
         </div>
         
-        <div id="relay_settings_6" class="tab-pane" data-bind="css: { active: 1 === 6 }, using: settings.plugins.octorelay.r6">
+        <div
+            id="relay_settings_6"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 6 }, using: settings.plugins.octorelay.r6"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -1159,6 +1764,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -1166,24 +1772,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input6" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input6"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -1200,8 +1829,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -1211,8 +1840,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -1223,13 +1852,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -1243,24 +1886,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1272,24 +1933,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1301,24 +1980,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1345,19 +2042,38 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
         </div>
         
-        <div id="relay_settings_7" class="tab-pane" data-bind="css: { active: 1 === 7 }, using: settings.plugins.octorelay.r7">
+        <div
+            id="relay_settings_7"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 7 }, using: settings.plugins.octorelay.r7"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -1367,6 +2083,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -1374,24 +2091,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input7" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input7"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -1408,8 +2148,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -1419,8 +2159,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -1431,13 +2171,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -1451,24 +2205,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1480,24 +2252,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1509,24 +2299,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1553,19 +2361,38 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
             </div>
         </div>
         
-        <div id="relay_settings_8" class="tab-pane" data-bind="css: { active: 1 === 8 }, using: settings.plugins.octorelay.r8">
+        <div
+            id="relay_settings_8"
+            class="tab-pane"
+            data-bind="css: { active: 1 === 8 }, using: settings.plugins.octorelay.r8"
+        >
+
             <div class="control-group">
                 <label class="control-label">Active</label>
                 <div class="controls">
                     <div class="btn-group">
                         
-                        <label class="btn" data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: true, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-info\': active() === true, \'btn-default\': active() !== true }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: true, checked: active"
+                            />
                             YES
                         </label>
                         
-                        <label class="btn" data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }">
-                            <input type="radio" style="display:none" data-bind="checkedValue: false, checked: active" />
+                        <label
+                            class="btn"
+                            data-bind="css: { \'active btn-default\': active() === false, \'btn-default\': active() !== false }"
+                        >
+                            <input
+                                type="radio"
+                                style="display: none"
+                                data-bind="checkedValue: false, checked: active"
+                            />
                             NO
                         </label>
                         
@@ -1575,6 +2402,7 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     </span>
                 </div>
             </div>
+
             <div data-bind="visible: active">
                 <div class="control-group">
                     <label class="control-label">Label</label>
@@ -1582,24 +2410,47 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                         <input type="text" class="input-small" data-bind="value: label_text">
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">GPIO Number</label>
                     <div class="controls">
-                        <input id="relay_pin-input8" type="number" min="1" max="27" class="input-small" data-bind="value: relay_pin">
+                        <input
+                            id="relay_pin-input8"
+                            type="number"
+                            min="1"
+                            max="27"
+                            class="input-small"
+                            data-bind="value: relay_pin"
+                        >
                     </div>
                 </div>
+
                 <div class="control-group">
                     <label class="control-label">Inverted output</label>
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': inverted_output() === true, \'btn-default\': inverted_output() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: inverted_output"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: inverted_output" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': inverted_output() === false, \'btn-default\': inverted_output() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: inverted_output"
+                                />
                                 NO
                             </label>
                             
@@ -1616,8 +2467,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_on">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_on"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_on"
                         ></div>
                     </div>
                 </div>
@@ -1627,8 +2478,8 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <input type="text" class="input-large" data-bind="value: icon_off">
                         <div
-                                style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
-                                data-bind="html: icon_off"
+                            style="display: inline-flex; width: 24px; height: 24px; margin-left: 8px; overflow: hidden; line-height: unset; vertical-align: middle; font-size: 1.25rem; align-items: center; justify-content: center;"
+                            data-bind="html: icon_off"
                         ></div>
                     </div>
                 </div>
@@ -1639,13 +2490,27 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-info\': confirm_off() === true, \'btn-default\': confirm_off() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: true, checked: confirm_off"
+                                />
                                 YES
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: confirm_off" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': confirm_off() === false, \'btn-default\': confirm_off() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none"
+                                    data-bind="checkedValue: false, checked: confirm_off"
+                                />
                                 NO
                             </label>
                             
@@ -1659,24 +2524,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1688,24 +2571,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1717,24 +2618,42 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
                     <div class="controls">
                         <div class="btn-group">
                             
-                            <label class="btn" data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: true, checked: state" />
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-success\': state() === true, \'btn-default\': state() !== true }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: true, checked: state"
+                                />
                                 ON
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: false, checked: state" />
-                                OFF
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: null, checked: state"
+                                />
+                                skip
                             </label>
                             
-                            <label class="btn" data-bind="css: { \'active btn-default\': state() === null, \'btn-default\': state() !== null }">
-                                <input type="radio" style="display:none" data-bind="checkedValue: null, checked: state" />
-                                skip
+                            <label
+                                class="btn"
+                                data-bind="css: { \'active btn-danger\': state() === false, \'btn-default\': state() !== false }"
+                            >
+                                <input
+                                    type="radio"
+                                    style="display: none" data-bind="checkedValue: false, checked: state"
+                                />
+                                OFF
                             </label>
                             
                         </div>
                         <div class="input-prepend input-append" data-bind="hidden: state() === null">
-                            <span class="add-on">Delay</span>
+                            <span class="add-on">delay</span>
                             <input type="number" min="0" max="86400" class="input-mini" data-bind="value: delay">
                             <span class="add-on">s</span>
                         </div>
@@ -1762,5 +2681,4 @@ snapshots['TestTemplates::test_templates octorelay_settings.jinja2'] = '''<form 
         </div>
         
     </div>
-
 </form>'''

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -53,7 +53,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_constructor(self):
         # During the instantiation should set initial values to certain props
         self.assertIsNone(self.plugin_instance.polling_timer)
-        self.assertEqual(self.plugin_instance.timers, [])
+        self.assertEqual(self.plugin_instance.tasks, [])
         self.assertEqual(self.plugin_instance.model, {
             "r1": {}, "r2": {}, "r3": {}, "r4": {},
             "r5": {}, "r6": {}, "r7": {}, "r8": {}
@@ -522,7 +522,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     def test_handle_plugin_event(self):
         # Should follow the rule on handling the event by toggling the relay if "state" is not None
-        self.plugin_instance.timers = [{"subject": "r4", "timer": timerMock}]
+        self.plugin_instance.tasks = [{"subject": "r4", "timer": timerMock}]
         self.plugin_instance.cancel_timers = Mock()
         cases = [
             { "event": "PRINTING_STARTED", "state": True, "expectedCall": True },
@@ -536,7 +536,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             { "event": "STARTUP", "state": None, "expectedCall": False },
         ]
         for case in cases:
-            self.plugin_instance.timers = []
+            self.plugin_instance.tasks = []
             utilMock.ResettableTimer.reset_mock()
             timerMock.start.reset_mock()
             self.plugin_instance.toggle_relay = Mock()
@@ -559,7 +559,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 )
                 timerMock.start.assert_called_with()
                 self.assertEqual(
-                    self.plugin_instance.timers,
+                    self.plugin_instance.tasks,
                     list(map(lambda index, reason=case["event"]: {
                         "subject": index,
                         "reason": reason,
@@ -572,7 +572,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     def test_cancel_timers__exception(self):
         # Should handle a possible exception when cancelling the timer
-        self.plugin_instance.timers = [{
+        self.plugin_instance.tasks = [{
             "subject": "r4",
             "timer": Mock(
                 cancel=Mock( side_effect=Exception("Caught!") )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -306,6 +306,27 @@ class TestOctoRelayPlugin(unittest.TestCase):
         actual = self.plugin_instance.get_template_configs()
         self.assertEqual(actual, expected)
 
+    def test_get_template_vars(self):
+        # Should return the variables needed for the settings template
+        expected = {
+            "events": {
+                "STARTUP": "on Startup",
+                "PRINTING_STARTED": "on Printing Started",
+                "PRINTING_STOPPED": "on Printing Stopped"
+            },
+            "boolean": {
+                "true": { "caption": "YES", "color": "info" },
+                "false": { "caption": "NO", "color": "default" }
+            },
+            "tristate": {
+                "true": { "caption": "ON", "color": "success" },
+                "false": { "caption": "OFF", "color": "danger" },
+                "null": { "caption": "skip", "color": "default" },
+            }
+        }
+        actual = self.plugin_instance.get_template_vars()
+        self.assertEqual(actual, expected)
+
     def test_get_template_configs__immutable(self):
         # Check that the function returns new object each time
         first = self.plugin_instance.get_template_configs()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -523,7 +523,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_handle_plugin_event(self):
         # Should follow the rule on handling the event by toggling the relay if "state" is not None
         self.plugin_instance.tasks = [{"subject": "r4", "timer": timerMock}]
-        self.plugin_instance.cancel_timers = Mock()
+        self.plugin_instance.cancel_tasks = Mock()
         cases = [
             { "event": "PRINTING_STARTED", "state": True, "expectedCall": True },
             { "event": "PRINTING_STARTED", "state": False, "expectedCall": True },
@@ -552,7 +552,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 } for index in RELAY_INDEXES
             })
             self.plugin_instance.handle_plugin_event(case["event"])
-            self.plugin_instance.cancel_timers.assert_called_with()
+            self.plugin_instance.cancel_tasks.assert_called_with()
             if case["expectedCall"]:
                 utilMock.ResettableTimer.assert_called_with(
                     300, self.plugin_instance.toggle_relay, ["r8", case["state"]]
@@ -570,15 +570,15 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 utilMock.ResettableTimer.assert_not_called()
                 timerMock.start.assert_not_called()
 
-    def test_cancel_timers__exception(self):
-        # Should handle a possible exception when cancelling the timer
+    def test_cancel_tasks__exception(self):
+        # Should handle a possible exception when cancelling a timer
         self.plugin_instance.tasks = [{
             "subject": "r4",
             "timer": Mock(
                 cancel=Mock( side_effect=Exception("Caught!") )
             )
         }]
-        self.plugin_instance.cancel_timers()
+        self.plugin_instance.cancel_tasks()
         self.plugin_instance._logger.warn.assert_called_with("failed to cancel timer 0 for r4, reason: Caught!")
 
     def test_has_switch_permission(self):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -715,6 +715,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             }
         ]
         for case in cases:
+            self.plugin_instance.update_ui.mock_reset()
             relayMock.is_closed = Mock(return_value=case["closed"])
             relayMock.toggle = Mock(return_value=not case["closed"])
             permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
@@ -739,6 +740,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 jsonify_mock.assert_called_with(case["expectedJson"])
             if "expectedToggle" in case:
                 relayMock.toggle.assert_called_with(None)
+                self.plugin_instance.update_ui.assert_called_with()
             if "expectedCommand" in case:
                 system_mock.assert_called_with(case["expectedCommand"])
             if "expectedStatus" in case:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -570,10 +570,23 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 utilMock.ResettableTimer.assert_not_called()
                 timerMock.start.assert_not_called()
 
+    def test_cancel_tasks(self):
+        # Should clear the tasks queue and cancel its timers
+        timerMock.mock_reset()
+        self.plugin_instance.tasks = [{
+            "subject": "r4",
+            "reason": "PRINTING_STOPPED",
+            "timer": timerMock
+        }]
+        self.plugin_instance.cancel_tasks()
+        self.assertEqual(self.plugin_instance.tasks, [])
+        timerMock.cancel.assert_called_with()
+
     def test_cancel_tasks__exception(self):
         # Should handle a possible exception when cancelling a timer
         self.plugin_instance.tasks = [{
             "subject": "r4",
+            "reason": "PRINTING_STOPPED",
             "timer": Mock(
                 cancel=Mock( side_effect=Exception("Caught!") )
             )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -60,9 +60,11 @@ class TestOctoRelayPlugin(unittest.TestCase):
         })
 
     def test_get_settings_version(self):
+        # Should return the current version of settings defaults
         self.assertEqual(self.plugin_instance.get_settings_version(), 3)
 
     def test_get_settings_defaults(self):
+        # Should return the plugin default settings
         expected = {
             "r1": {
                 "active": False,
@@ -296,6 +298,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.plugin_instance._logger.info.assert_called_with("OctoRelay finished the migration of settings to v1")
 
     def test_get_template_configs(self):
+        # Should return the plugin template configurations
         expected = [
             { "type": "navbar", "custom_bindings": False },
             { "type": "settings", "custom_bindings": False }
@@ -312,16 +315,19 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.assertEqual(second[0]["type"], "navbar")
 
     def test_get_assets(self):
+        # Should return the plugin assets configutation
         expected = { "js": [ "js/octorelay.js" ] }
         actual = self.plugin_instance.get_assets()
         self.assertEqual(actual, expected)
 
     def test_get_api_commands(self):
+        # Should return the list of available plugin commands
         expected = { "update": [ "pin" ], "getStatus": [ "pin" ], "listAllStatus": [] }
         actual = self.plugin_instance.get_api_commands()
         self.assertEqual(actual, expected)
 
     def test_get_update_information(self):
+        # Should return the update strategy configuration
         expected = {
             "octorelay": {
                 "displayName": "OctoRelay",
@@ -347,12 +353,15 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_python_compatibility(self):
+        # Should be the current Python compability string
         self.assertEqual(__plugin_pythoncompat__, ">=3.7,<4")
 
     def test_exposed_implementation(self):
+        # Should be an instance of the plugin class
         self.assertIsInstance(__plugin_implementation__, OctoRelayPlugin)
 
     def test_exposed_hooks(self):
+        # Should be an object having handlers associated to the certain OctoPrint hooks
         expected = {
             "octoprint.plugin.softwareupdate.check_config":
                 __plugin_implementation__.get_update_information,
@@ -364,6 +373,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.assertEqual(__plugin_hooks__, expected)
 
     def test_on_shutdown(self):
+        # Should stop the polling timer
         self.plugin_instance.polling_timer = Mock()
         self.plugin_instance.on_shutdown()
         self.plugin_instance.polling_timer.cancel.assert_called_with()
@@ -426,12 +436,13 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     @patch("os.system")
     def test_toggle_relay(self, system_mock):
-        # Should turn the relay off and execute the supplied command
+        # Should toggle the relay and execute a command matching its new state
         cases = [
             { "target": True, "inverted": False, "expectedCommand": "CommandON" },
             { "target": True, "inverted": True, "expectedCommand": "CommandON" },
             { "target": False, "inverted": False, "expectedCommand": "CommandOFF" },
             { "target": False, "inverted": True, "expectedCommand": "CommandOFF" },
+            # in these cases the resulting relay state is mocked with the "inverted" value:
             { "target": None, "inverted": False, "expectedCommand": "CommandOFF" },
             { "target": None, "inverted": True, "expectedCommand": "CommandON" }
         ]
@@ -498,7 +509,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             case["expectedMethod"].assert_called_with(*case["expectedParams"])
 
     def test_on_after_startup(self):
-        # Depending on actual settings should set the relay state, update UI and start polling
+        # Should trigger STARTUP event handler, update UI and start polling
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.handle_plugin_event = Mock()
         self.plugin_instance.on_after_startup()
@@ -510,7 +521,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         timerMock.start.assert_called_with()
 
     def test_handle_plugin_event(self):
-        # For relays configured with autoON should call turn_on_relay method and update UI
+        # Should follow the rule on handling the event by toggling the relay if "state" is not None
         self.plugin_instance.timers = [{"subject": "r4", "timer": timerMock}]
         cases = [
             { "event": "PRINTING_STARTED", "state": True, "expectedCall": True },
@@ -697,12 +708,13 @@ class TestOctoRelayPlugin(unittest.TestCase):
         abort_mock.assert_called_with(400)
 
     def test_process_at_command(self):
-        # Should call toggle_relay() method with supplied parameter
+        # Should toggle the relay having index supplied as a parameter
         self.plugin_instance.toggle_relay = Mock()
         self.assertIsNone(self.plugin_instance.process_at_command(None, None, "OCTORELAY", "r4"))
         self.plugin_instance.toggle_relay.assert_called_with("r4")
 
     def test_get_additional_permissions(self):
+        # Should return the list of the plugin custom permissions
         expected = [{
             "key": "SWITCH",
             "name": "Relay switching",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -560,9 +560,9 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 timerMock.start.assert_called_with()
                 self.assertEqual(
                     self.plugin_instance.tasks,
-                    list(map(lambda index, reason=case["event"]: {
+                    list(map(lambda index, owner=case["event"]: {
                         "subject": index,
-                        "reason": reason,
+                        "owner": owner,
                         "timer": timerMock
                     }, RELAY_INDEXES))
                 )
@@ -575,11 +575,11 @@ class TestOctoRelayPlugin(unittest.TestCase):
         timerMock.mock_reset()
         self.plugin_instance.tasks = [{
             "subject": "r4",
-            "reason": "PRINTING_STOPPED",
+            "owner": "PRINTING_STOPPED",
             "timer": timerMock
         }, {
             "subject": "r4",
-            "reason": "STARTUP",
+            "owner": "STARTUP",
             "timer": timerMock
         }]
         self.plugin_instance.cancel_tasks("r4")
@@ -590,7 +590,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Should handle a possible exception when cancelling a timer
         self.plugin_instance.tasks = [{
             "subject": "r4",
-            "reason": "PRINTING_STOPPED",
+            "owner": "PRINTING_STOPPED",
             "timer": Mock(
                 cancel=Mock( side_effect=Exception("Caught!") )
             )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -631,6 +631,12 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "expectedStatus": "ok",
                 "expectedToggle": True,
                 "expectedCommand": "CommandOffMock"
+            },
+            {
+                "command": "update",
+                "data": { "pin": "invalid" },
+                "closed": True,
+                "expectedStatus": "error",
             }
         ]
         for case in cases:
@@ -646,7 +652,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "cmd_off": "CommandOffMock"
             })
             self.plugin_instance.on_api_command(case["command"], case["data"])
-            if case["command"] != "listAllStatus":
+            if case["command"] != "listAllStatus" and case["expectedStatus"] != "error":
                 self.plugin_instance._settings.get.assert_called_with(["r4"], merged=True)
             if "expectedJson" in case:
                 jsonify_mock.assert_called_with(case["expectedJson"])

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -156,65 +156,13 @@ class TestMigrations(unittest.TestCase):
                 })
 
     def test_migrate(self):
-        # Should call all migrations in a band
-        dump = {
-            index: {
-                "active": False,
-                "relay_pin": 23,
-                "inverted_output": True,
-                "initial_value": True,
-                "cmdON": "sudo service webcamd start",
-                "cmdOFF": "sudo service webcamd stop",
-                "iconOn": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
-                "iconOff": (
-                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
-                    """style="filter: opacity(20%)">"""
-                ),
-                "labelText": "Webcam",
-                "confirmOff": False,
-                "autoONforPrint": True,
-                "autoOFFforPrint": True,
-                "autoOffDelay": 10,
-            } for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]
-        }
-        def setter(path, value):
-            dump[path[0]] = value
+        # Should call all migrations
         settings = Mock(
-            get = lambda path, **kwargs:dump[path[0]],
-            set = setter
+            get = Mock(return_value={})
         )
         logger = Mock()
         migrate(0, settings, logger)
-        self.assertEqual(dump, {
-            index: {
-                "active": False,
-                "relay_pin": 23,
-                "inverted_output": True,
-                "cmd_on": "sudo service webcamd start",
-                "cmd_off": "sudo service webcamd stop",
-                "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
-                "icon_off": (
-                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
-                    """style="filter: opacity(20%)">"""
-                ),
-                "label_text": "Webcam",
-                "confirm_off": False,
-                "rules": {
-                    "STARTUP": {
-                        "state": True,
-                        "delay": 0
-                    },
-                    "PRINTING_STARTED": {
-                        "state": True,
-                        "delay": 0
-                    },
-                    "PRINTING_STOPPED": {
-                        "state": False,
-                        "delay": 10
-                    }
-                }
-            } for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]
-        })
+        logger.info.assert_any_call("OctoRelay migrates to settings v1")
 
 
 if __name__ == "__main__":

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -82,57 +82,78 @@ class TestMigrations(unittest.TestCase):
             })
 
     def test_v2(self):
-        settings = Mock(
-            get=Mock(return_value={
-                "active": False,
-                "relay_pin": 23,
-                "inverted_output": True,
-                "initial_value": True,
-                "cmd_on": "sudo service webcamd start",
-                "cmd_off": "sudo service webcamd stop",
-                "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
-                "icon_off": (
-                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
-                    """style="filter: opacity(20%)">"""
-                ),
-                "label_text": "Webcam",
-                "confirm_off": False,
-                "auto_on_before_print": True,
-                "auto_off_after_print": True,
-                "auto_off_delay": 10,
-            })
-        )
-        logger = Mock()
-        v2(settings, logger)
-        for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]:
-            settings.set.assert_any_call([index], {
-                "active": False,
-                "relay_pin": 23,
-                "inverted_output": True,
-                "cmd_on": "sudo service webcamd start",
-                "cmd_off": "sudo service webcamd stop",
-                "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
-                "icon_off": (
-                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
-                    """style="filter: opacity(20%)">"""
-                ),
-                "label_text": "Webcam",
-                "confirm_off": False,
-                "rules": {
-                    "STARTUP": {
-                        "state": True,
-                        "delay": 0
-                    },
-                    "PRINTING_STARTED": {
-                        "state": True,
-                        "delay": 0
-                    },
-                    "PRINTING_STOPPED": {
-                        "state": False,
-                        "delay": 10
+        cases = [
+            {
+                "feed": {
+                    "initial_value": True,
+                    "auto_on_before_print": True,
+                    "auto_off_after_print": True,
+                    "auto_off_delay": 10,
+                },
+                "expected_startup_state": True,
+                "expected_printing_started_state": True,
+                "expected_printing_stopped_state": False,
+            }, {
+                "feed": {
+                    "initial_value": False,
+                    "auto_on_before_print": False,
+                    "auto_off_after_print": False,
+                    "auto_off_delay": 0,
+                },
+                "expected_startup_state": False,
+                "expected_printing_started_state": None,
+                "expected_printing_stopped_state": None,
+            }
+        ]
+        for case in cases:
+            settings = Mock(
+                get=Mock(return_value={
+                    "active": False,
+                    "relay_pin": 23,
+                    "inverted_output": True,
+                    "cmd_on": "sudo service webcamd start",
+                    "cmd_off": "sudo service webcamd stop",
+                    "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
+                    "icon_off": (
+                        """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
+                        """style="filter: opacity(20%)">"""
+                    ),
+                    "label_text": "Webcam",
+                    "confirm_off": False,
+                    **case["feed"]
+                })
+            )
+            logger = Mock()
+            v2(settings, logger)
+            for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]:
+                settings.set.assert_any_call([index], {
+                    "active": False,
+                    "relay_pin": 23,
+                    "inverted_output": True,
+                    "cmd_on": "sudo service webcamd start",
+                    "cmd_off": "sudo service webcamd stop",
+                    "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
+                    "icon_off": (
+                        """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
+                        """style="filter: opacity(20%)">"""
+                    ),
+                    "label_text": "Webcam",
+                    "confirm_off": False,
+                    "rules": {
+                        "STARTUP": {
+                            "state": case["expected_startup_state"],
+                            "delay": 0
+                        },
+                        "PRINTING_STARTED": {
+                            "state": case["expected_printing_started_state"],
+                            "delay": 0
+                        },
+                        "PRINTING_STOPPED": {
+                            "state": case["expected_printing_stopped_state"],
+                            "delay": case["feed"]["auto_off_delay"]
+                        }
                     }
-                }
-            })
+                })
 
     def test_migrate(self):
         # Should call all migrations

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -156,13 +156,65 @@ class TestMigrations(unittest.TestCase):
                 })
 
     def test_migrate(self):
-        # Should call all migrations
+        # Should call all migrations in a band
+        dump = {
+            index: {
+                "active": False,
+                "relay_pin": 23,
+                "inverted_output": True,
+                "initial_value": True,
+                "cmdON": "sudo service webcamd start",
+                "cmdOFF": "sudo service webcamd stop",
+                "iconOn": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
+                "iconOff": (
+                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
+                    """style="filter: opacity(20%)">"""
+                ),
+                "labelText": "Webcam",
+                "confirmOff": False,
+                "autoONforPrint": True,
+                "autoOFFforPrint": True,
+                "autoOffDelay": 10,
+            } for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]
+        }
+        def setter(path, value):
+            dump[path[0]] = value
         settings = Mock(
-            get = Mock(return_value={})
+            get = lambda path, **kwargs:dump[path[0]],
+            set = setter
         )
         logger = Mock()
         migrate(0, settings, logger)
-        logger.info.assert_any_call("OctoRelay migrates to settings v1")
+        self.assertEqual(dump, {
+            index: {
+                "active": False,
+                "relay_pin": 23,
+                "inverted_output": True,
+                "cmd_on": "sudo service webcamd start",
+                "cmd_off": "sudo service webcamd stop",
+                "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
+                "icon_off": (
+                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
+                    """style="filter: opacity(20%)">"""
+                ),
+                "label_text": "Webcam",
+                "confirm_off": False,
+                "rules": {
+                    "STARTUP": {
+                        "state": True,
+                        "delay": 0
+                    },
+                    "PRINTING_STARTED": {
+                        "state": True,
+                        "delay": 0
+                    },
+                    "PRINTING_STOPPED": {
+                        "state": False,
+                        "delay": 10
+                    }
+                }
+            } for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]
+        })
 
 
 if __name__ == "__main__":

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -13,7 +13,7 @@ sys.modules["RPi.GPIO"] = Mock()
 
 # pylint: disable=wrong-import-position
 from octoprint_octorelay.const import SETTINGS_VERSION
-from octoprint_octorelay.migrations import migrators, migrate, v0, v1
+from octoprint_octorelay.migrations import migrators, migrate, v0, v1, v2
 
 # avoid keeping other modules automatically imported by this test
 del sys.modules["octoprint_octorelay"]
@@ -79,6 +79,59 @@ class TestMigrations(unittest.TestCase):
                 "auto_on_before_print": True,
                 "auto_off_after_print": True,
                 "auto_off_delay": 10,
+            })
+
+    def test_v2(self):
+        settings = Mock(
+            get=Mock(return_value={
+                "active": False,
+                "relay_pin": 23,
+                "inverted_output": True,
+                "initial_value": True,
+                "cmd_on": "sudo service webcamd start",
+                "cmd_off": "sudo service webcamd stop",
+                "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
+                "icon_off": (
+                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
+                    """style="filter: opacity(20%)">"""
+                ),
+                "label_text": "Webcam",
+                "confirm_off": False,
+                "auto_on_before_print": True,
+                "auto_off_after_print": True,
+                "auto_off_delay": 10,
+            })
+        )
+        logger = Mock()
+        v2(settings, logger)
+        for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]:
+            settings.set.assert_any_call([index], {
+                "active": False,
+                "relay_pin": 23,
+                "inverted_output": True,
+                "cmd_on": "sudo service webcamd start",
+                "cmd_off": "sudo service webcamd stop",
+                "icon_on": """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" >""",
+                "icon_off": (
+                    """<img width="24" height="24" src="/plugin/octorelay/static/img/webcam.svg" """
+                    """style="filter: opacity(20%)">"""
+                ),
+                "label_text": "Webcam",
+                "confirm_off": False,
+                "rules": {
+                    "STARTUP": {
+                        "state": True,
+                        "delay": 0
+                    },
+                    "PRINTING_STARTED": {
+                        "state": True,
+                        "delay": 0
+                    },
+                    "PRINTING_STOPPED": {
+                        "state": False,
+                        "delay": 10
+                    }
+                }
             })
 
     def test_migrate(self):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,8 +1,19 @@
 # -*- coding: utf-8 -*-
 import unittest
+import sys
+from unittest.mock import Mock
 from snapshottest import TestCase
 from jinja2 import Environment, FileSystemLoader
+
+# Mocking required before the further import
+sys.modules["RPi.GPIO"] = Mock()
+
+# pylint: disable=wrong-import-position
 from octoprint_octorelay.const import get_ui_vars
+
+# avoid keeping other modules automatically imported by this test
+if "octoprint_octorelay" in sys.modules:
+    del sys.modules["octoprint_octorelay"]
 
 environment = Environment(loader=FileSystemLoader("../octoprint_octorelay/templates/"))
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -2,6 +2,7 @@
 import unittest
 from snapshottest import TestCase
 from jinja2 import Environment, FileSystemLoader
+from octoprint_octorelay.const import get_ui_vars
 
 environment = Environment(loader=FileSystemLoader("../octoprint_octorelay/templates/"))
 
@@ -11,10 +12,12 @@ class TestTemplates(TestCase):
             "octorelay_settings.jinja2",
             "octorelay_navbar.jinja2"
         ]
+        vars = get_ui_vars()
         for file in files:
             template = environment.get_template(file)
             html = template.render({
-                "_": lambda value: value
+                "_": lambda value: value,
+                **{ "plugin_octorelay_" + key: value for key, value in vars.items() }
             })
             self.assertMatchSnapshot(html, file)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -12,12 +12,12 @@ class TestTemplates(TestCase):
             "octorelay_settings.jinja2",
             "octorelay_navbar.jinja2"
         ]
-        vars = get_ui_vars()
+        ui_vars = get_ui_vars()
         for file in files:
             template = environment.get_template(file)
             html = template.render({
                 "_": lambda value: value,
-                **{ "plugin_octorelay_" + key: value for key, value in vars.items() }
+                **{ "plugin_octorelay_" + key: value for key, value in ui_vars.items() }
             })
             self.assertMatchSnapshot(html, file)
 

--- a/ts/bindings.spec.ts
+++ b/ts/bindings.spec.ts
@@ -7,32 +7,38 @@ describe("Knockout bindings", () => {
     "utf-8"
   );
   const document = JSDOM.fragment(html);
-  const settingRegex = /^settings\.plugins\.octorelay\.r{{n}}.(\w+)$/;
+  const usingContexts = [
+    "settings.plugins.octorelay.r{{n}}",
+    "rules.{{event}}",
+  ];
+  const settingRegex = /([\w\{}]+).*$/;
   const relaySettings = [
     "active",
     "relay_pin",
     "inverted_output",
-    "initial_value",
     "label_text",
-    "cmd_on",
-    "cmd_off",
-    "auto_on_before_print",
-    "auto_off_after_print",
-    "auto_off_delay",
-    "icon_on",
-    "icon_off",
+    "cmd_{{state}}", // on/off added programmatically
+    "icon_{{state}}", // on/off added programmatically
     "confirm_off",
+    "state",
+    "delay",
   ];
 
-  // @todo update this test
-  test.skip("Settings template should have bindings to the correctly named settings", () => {
+  test("Settings template should have bindings to the correctly named settings", () => {
     const elements = Array.from(document.querySelectorAll("[data-bind]"));
     expect(elements.length).toBeGreaterThan(0);
     for (const element of elements) {
       const bindings = element.getAttribute("data-bind")?.split(",") || [];
       expect(bindings.length).toBeGreaterThan(0);
       for (const binding of bindings) {
-        const [{}, address] = binding.trim().split(":");
+        const [keyword, address] = binding.trim().split(":");
+        if (["checkedValue", "css"].includes(keyword)) {
+          continue;
+        }
+        if (keyword === "using") {
+          expect(usingContexts.includes(address.trim())).toBeTruthy();
+          continue;
+        }
         expect(settingRegex.test(address.trim())).toBeTruthy();
         const match = address.trim().match(settingRegex);
         const relaySetting = match?.[1];

--- a/ts/bindings.spec.ts
+++ b/ts/bindings.spec.ts
@@ -24,7 +24,8 @@ describe("Knockout bindings", () => {
     "confirm_off",
   ];
 
-  test("Settings template should have bindings to the correctly named settings", () => {
+  // @todo update this test
+  test.skip("Settings template should have bindings to the correctly named settings", () => {
     const elements = Array.from(document.querySelectorAll("[data-bind]"));
     expect(elements.length).toBeGreaterThan(0);
     for (const element of elements) {


### PR DESCRIPTION
This should make the plugin more flexible for implementing more reactions in the future.
Closes #28 

### Approach

For each relay, instead of having these config props:
```
initial_value, auto_on_before_print, auto_off_after_print, auto_off_delay
```

I'm making a more generic object `rules` having entries matching the following events:
```
STARTUP, PRINTING_STARTED, PRINTING_STOPPED
```

Each of those entries is an object having following properties:
- `state` — the desired relay state in case of the event
  - except `None` meaning "no action needed"
- `delay` — the delay for performing that action (seconds)

Thus, 

- `initial_value` becomes `bool` in `rules/STARTUP/state`
- `auto_on_before_print` becomes `True | None` in `rules/PRINTING_STARTED/state`
- `auto_off_after_print` becomes `False | None` in `rules/PRINTING_STOPPED/state`
- `auto_off_delay` becomes `rules/PRINTING_STOPPED/delay`

This enables the following behaviours:
- auto OFF before printing
- auto ON after printing #28 

As well as adding more events in the future, such as ones needed for
- #27
- #20
- #87 and more.

### The new UI 🌈 💅🏽 

<img width="704" alt="Screenshot 2023-08-10 at 21 09 44" src="https://github.com/borisbu/OctoRelay/assets/13189514/9199e3f1-50f3-4ef9-9245-6c04e544db7d">

### Todo

- [x] todos in code
- [x] tests
- [x] functions' descriptions
- [x] migration
- [x] UI