### PR TITLE
Using `merged=True` for getting settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 3
 
+### 3.3.2
+
+- Refactoring: using `merged=True` option for consistent retrieval of the relay settings.
+
 ### 3.3.1
 
 - Refactoring: consistent naming for the plugin settings.
@@ -17,7 +21,7 @@
 | `autoOffDelay`    | `auto_off_delay`       |
 | `iconOn`          | `icon_on`              |
 | `iconOff`         | `icon_off`             |
-| `confirmOff`      | `confirm_off`          | 
+| `confirmOff`      | `confirm_off`          |
 
 ### 3.3.0
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -60,17 +60,16 @@ class OctoRelayPlugin(
     def on_after_startup(self):
         self._logger.info("--------------------------------------------")
         self._logger.info("start OctoRelay")
-        settings = get_default_settings()
 
         for index in RELAY_INDEXES:
-            settings[index].update(self._settings.get([index]))
-            self._logger.debug(f"settings for {index}: {settings[index]}")
+            settings = self._settings.get([index], merged=True)
+            self._logger.debug(f"settings for {index}: {settings}")
 
-            if settings[index]["active"]:
+            if settings["active"]:
                 Relay(
-                    int(settings[index]["relay_pin"]),
-                    bool(settings[index]["inverted_output"])
-                ).toggle( bool(settings[index]["initial_value"]) )
+                    int(settings["relay_pin"]),
+                    bool(settings["inverted_output"])
+                ).toggle(bool(settings["initial_value"]))
 
         self.update_ui()
         self.polling_timer = RepeatedTimer(POLLING_INTERVAL, self.input_polling, daemon=True)
@@ -233,25 +232,24 @@ class OctoRelayPlugin(
             os.system(cmd)
 
     def update_ui(self):
-        settings = get_default_settings()
         for index in RELAY_INDEXES:
-            settings[index].update(self._settings.get([index]))
+            settings = self._settings.get([index], merged=True)
             relay = Relay(
-                int(settings[index]["relay_pin"]),
-                bool(settings[index]["inverted_output"])
+                int(settings["relay_pin"]),
+                bool(settings["inverted_output"])
             )
             relay_state = relay.is_closed()
             # set the icon state
             self.model[index]["relay_pin"] = relay.pin
             self.model[index]["inverted_output"] = relay.inverted
             self.model[index]["relay_state"] = relay_state # bool since v3.1
-            self.model[index]["label_text"] = settings[index]["label_text"]
-            self.model[index]["active"] = bool(settings[index]["active"])
+            self.model[index]["label_text"] = settings["label_text"]
+            self.model[index]["active"] = bool(settings["active"])
             if relay_state:
-                self.model[index]["icon_html"] = settings[index]["icon_on"]
-                self.model[index]["confirm_off"] = bool(settings[index]["confirm_off"])
+                self.model[index]["icon_html"] = settings["icon_on"]
+                self.model[index]["confirm_off"] = bool(settings["confirm_off"])
             else:
-                self.model[index]["icon_html"] = settings[index]["icon_off"]
+                self.model[index]["icon_html"] = settings["icon_off"]
                 self.model[index]["confirm_off"] = False
 
         #self._logger.info(f"update ui with model {self.model}")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -335,7 +335,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             self.plugin_instance.update_ui()
             relayConstructorMock.assert_called_with(17, False)
             for index in self.plugin_instance.get_settings_defaults():
-                self.plugin_instance._settings.get.assert_any_call([index])
+                self.plugin_instance._settings.get.assert_any_call([index], merged=True)
             self.plugin_instance._plugin_manager.send_plugin_message.assert_called_with(
                 "MockedIdentifier", expected_model
             )


### PR DESCRIPTION
Closes #150 

- Consistently operating the relay settings.
- Less statements.