### PR TITLE
Read all relay settings once (fix performance)

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -60,21 +60,17 @@ class OctoRelayPlugin(
     def on_after_startup(self):
         self._logger.info("--------------------------------------------")
         self._logger.info("start OctoRelay")
-
+        settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
-            settings = self._settings.get([index], merged=True)
-            self._logger.debug(f"settings for {index}: {settings}")
-
-            if settings["active"]:
+            self._logger.debug(f"settings for {index}: {settings[index]}")
+            if settings[index]["active"]:
                 Relay(
-                    int(settings["relay_pin"]),
-                    bool(settings["inverted_output"])
-                ).toggle(bool(settings["initial_value"]))
-
+                    int(settings[index]["relay_pin"]),
+                    bool(settings[index]["inverted_output"])
+                ).toggle(bool(settings[index]["initial_value"]))
         self.update_ui()
         self.polling_timer = RepeatedTimer(POLLING_INTERVAL, self.input_polling, daemon=True)
         self.polling_timer.start()
-
         self._logger.info("OctoRelay plugin started")
         self._logger.info("--------------------------------------------")
 
@@ -106,23 +102,23 @@ class OctoRelayPlugin(
         # API command to get relay statuses
         if command == LIST_ALL_COMMAND:
             active_relays = []
+            settings = self._settings.get([], merged=True) # expensive
             for index in RELAY_INDEXES:
-                settings = self._settings.get([index], merged=True)
-                if settings["active"]:
+                if settings[index]["active"]:
                     relay = Relay(
-                        int(settings["relay_pin"]),
-                        bool(settings["inverted_output"])
+                        int(settings[index]["relay_pin"]),
+                        bool(settings[index]["inverted_output"])
                     )
                     active_relays.append({
                         "id": index,
-                        "name": settings["label_text"],
+                        "name": settings[index]["label_text"],
                         "active": relay.is_closed(),
                     })
             return flask.jsonify(active_relays)
 
         # API command to get relay status
         if command == GET_STATUS_COMMAND:
-            settings = self._settings.get([data["pin"]], merged=True)
+            settings = self._settings.get([data["pin"]], merged=True) # expensive
             relay = Relay(
                 int(settings["relay_pin"]),
                 bool(settings["inverted_output"])
@@ -141,7 +137,7 @@ class OctoRelayPlugin(
 
     def update_relay(self, index):
         try:
-            settings = self._settings.get([index], merged=True)
+            settings = self._settings.get([index], merged=True) # expensive
             relay = Relay(
                 int(settings["relay_pin"]),
                 bool(settings["inverted_output"])
@@ -185,29 +181,27 @@ class OctoRelayPlugin(
                 self._logger.info(f"cancelled timer: {index}")
             except Exception as exception:
                 self._logger.warn(f"could not cancel timer: {index}, reason: {exception}")
+        settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
-            settings = self._settings.get([index], merged=True)
-
-            relay_pin = int(settings["relay_pin"])
-            inverted = bool(settings["inverted_output"])
-            auto_on = bool(settings["auto_on_before_print"])
-            cmd_on = settings["cmd_on"]
-            active = bool(settings["active"])
+            relay_pin = int(settings[index]["relay_pin"])
+            inverted = bool(settings[index]["inverted_output"])
+            auto_on = bool(settings[index]["auto_on_before_print"])
+            cmd_on = settings[index]["cmd_on"]
+            active = bool(settings[index]["active"])
             if auto_on and active:
                 self._logger.debug(f"turning on pin: {relay_pin}, index: {index}")
                 self.turn_on_relay(relay_pin, inverted, cmd_on)
         self.update_ui()
 
     def print_stopped(self):
+        settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
-            settings = self._settings.get([index], merged=True)
-
-            relay_pin = int(settings["relay_pin"])
-            inverted = bool(settings["inverted_output"])
-            auto_off = bool(settings["auto_off_after_print"])
-            delay = int(settings["auto_off_delay"])
-            cmd_off = settings["cmd_off"]
-            active = bool(settings["active"])
+            relay_pin = int(settings[index]["relay_pin"])
+            inverted = bool(settings[index]["inverted_output"])
+            auto_off = bool(settings[index]["auto_off_after_print"])
+            delay = int(settings[index]["auto_off_delay"])
+            cmd_off = settings[index]["cmd_off"]
+            active = bool(settings[index]["active"])
             if auto_off and active:
                 self._logger.debug(f"turn off pin: {relay_pin} in {delay} seconds. index: {index}")
                 self.turn_off_timers[index] = ResettableTimer(
@@ -232,26 +226,25 @@ class OctoRelayPlugin(
             os.system(cmd)
 
     def update_ui(self):
+        settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
-            settings = self._settings.get([index], merged=True)
             relay = Relay(
-                int(settings["relay_pin"]),
-                bool(settings["inverted_output"])
+                int(settings[index]["relay_pin"]),
+                bool(settings[index]["inverted_output"])
             )
             relay_state = relay.is_closed()
             # set the icon state
             self.model[index]["relay_pin"] = relay.pin
             self.model[index]["inverted_output"] = relay.inverted
             self.model[index]["relay_state"] = relay_state # bool since v3.1
-            self.model[index]["label_text"] = settings["label_text"]
-            self.model[index]["active"] = bool(settings["active"])
+            self.model[index]["label_text"] = settings[index]["label_text"]
+            self.model[index]["active"] = bool(settings[index]["active"])
             if relay_state:
-                self.model[index]["icon_html"] = settings["icon_on"]
-                self.model[index]["confirm_off"] = bool(settings["confirm_off"])
+                self.model[index]["icon_html"] = settings[index]["icon_on"]
+                self.model[index]["confirm_off"] = bool(settings[index]["confirm_off"])
             else:
-                self.model[index]["icon_html"] = settings["icon_off"]
+                self.model[index]["icon_html"] = settings[index]["icon_off"]
                 self.model[index]["confirm_off"] = False
-
         #self._logger.info(f"update ui with model {self.model}")
         self._plugin_manager.send_plugin_message(self._identifier, self.model)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -35,7 +35,9 @@ sys.modules["octoprint_octorelay.driver"] = Mock(
 )
 
 # pylint: disable=wrong-import-position
-from octoprint_octorelay import OctoRelayPlugin, __plugin_pythoncompat__, __plugin_implementation__, __plugin_hooks__
+from octoprint_octorelay import (
+    OctoRelayPlugin, __plugin_pythoncompat__, __plugin_implementation__, __plugin_hooks__, RELAY_INDEXES
+)
 
 class TestOctoRelayPlugin(unittest.TestCase):
     def setUp(self):
@@ -313,13 +315,15 @@ class TestOctoRelayPlugin(unittest.TestCase):
             relayMock.inverted = False
             relayMock.is_closed = Mock(return_value=case["closed"])
             self.plugin_instance._settings.get = Mock(return_value={
-                "active": True,
-                "relay_pin": relayMock.pin,
-                "inverted_output": False,
-                "icon_on": "ON",
-                "icon_off": "OFF",
-                "label_text": "TEST",
-                "confirm_off": False
+                index: {
+                    "active": True,
+                    "relay_pin": relayMock.pin,
+                    "inverted_output": False,
+                    "icon_on": "ON",
+                    "icon_off": "OFF",
+                    "label_text": "TEST",
+                    "confirm_off": False
+                } for index in RELAY_INDEXES
             })
             expected_model = {}
             for index in self.plugin_instance.get_settings_defaults():
@@ -335,7 +339,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             self.plugin_instance.update_ui()
             relayConstructorMock.assert_called_with(17, False)
             for index in self.plugin_instance.get_settings_defaults():
-                self.plugin_instance._settings.get.assert_any_call([index], merged=True)
+                self.plugin_instance._settings.get.assert_any_call([], merged=True)
             self.plugin_instance._plugin_manager.send_plugin_message.assert_called_with(
                 "MockedIdentifier", expected_model
             )
@@ -410,10 +414,12 @@ class TestOctoRelayPlugin(unittest.TestCase):
         ]
         for case in cases:
             self.plugin_instance._settings.get = Mock(return_value={
-                "active": True,
-                "relay_pin": 17,
-                "inverted_output": case["inverted"],
-                "initial_value": case["initial"]
+                index: {
+                    "active": True,
+                    "relay_pin": 17,
+                    "inverted_output": case["inverted"],
+                    "initial_value": case["initial"]
+                } for index in RELAY_INDEXES
             })
             self.plugin_instance.on_after_startup()
             relayConstructorMock.assert_called_with(17, case["inverted"])
@@ -437,11 +443,13 @@ class TestOctoRelayPlugin(unittest.TestCase):
         for case in cases:
             self.plugin_instance.turn_on_relay = Mock()
             self.plugin_instance._settings.get = Mock(return_value={
-                "active": True,
-                "relay_pin": 17,
-                "inverted_output": case["inverted"],
-                "auto_on_before_print": case["autoOn"],
-                "cmd_on": "CommandMock"
+                index: {
+                    "active": True,
+                    "relay_pin": 17,
+                    "inverted_output": case["inverted"],
+                    "auto_on_before_print": case["autoOn"],
+                    "cmd_on": "CommandMock"
+                } for index in RELAY_INDEXES
             })
             self.plugin_instance.print_started()
             timerMock.cancel.assert_called_with()
@@ -461,11 +469,13 @@ class TestOctoRelayPlugin(unittest.TestCase):
         }
         self.plugin_instance.turn_on_relay = Mock()
         self.plugin_instance._settings.get = Mock(return_value={
-            "active": False,
-            "relay_pin": 17,
-            "inverted_output": False,
-            "auto_on_before_print": False,
-            "cmd_on": None
+            index: {
+                "active": False,
+                "relay_pin": 17,
+                "inverted_output": False,
+                "auto_on_before_print": False,
+                "cmd_on": None
+            } for index in RELAY_INDEXES
         })
         self.plugin_instance.print_started()
         self.plugin_instance._logger.warn.assert_called_with("could not cancel timer: test, reason: Caught!")
@@ -484,12 +494,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
             utilMock.ResettableTimer.reset_mock()
             timerMock.start.reset_mock()
             self.plugin_instance._settings.get = Mock(return_value={
-                "active": True,
-                "relay_pin": 17,
-                "inverted_output": False,
-                "auto_off_after_print": case["autoOff"],
-                "auto_off_delay": 300,
-                "cmd_off": "CommandMock"
+                index: {
+                    "active": True,
+                    "relay_pin": 17,
+                    "inverted_output": False,
+                    "auto_off_after_print": case["autoOff"],
+                    "auto_off_delay": 300,
+                    "cmd_off": "CommandMock"
+                } for index in RELAY_INDEXES
             })
             self.plugin_instance.print_stopped()
             if case["expectedCall"]:
@@ -585,14 +597,20 @@ class TestOctoRelayPlugin(unittest.TestCase):
             relayMock.is_closed = Mock(return_value=case["closed"])
             relayMock.toggle = Mock(return_value=not case["closed"])
             permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
-            self.plugin_instance._settings.get = Mock(return_value={
+            relay_settings_mock = {
                 "active": True,
                 "relay_pin": 17,
                 "inverted_output": False,
                 "label_text": "TEST",
                 "cmd_on": "CommandOnMock",
                 "cmd_off": "CommandOffMock"
-            })
+            }
+            if case["command"] == "listAllStatus":
+                self.plugin_instance._settings.get = Mock(return_value={
+                    index: relay_settings_mock for index in RELAY_INDEXES
+                })
+            else:
+                self.plugin_instance._settings.get = Mock(return_value=relay_settings_mock)
             self.plugin_instance.on_api_command(case["command"], case["data"])
             if case["command"] != "listAllStatus":
                 self.plugin_instance._settings.get.assert_called_with(["r4"], merged=True)


### PR DESCRIPTION
Closes #150 

Due to performance issues [revealed](https://github.com/borisbu/OctoRelay/pull/161#issuecomment-1670301028) during the QA of #159 

Instead of reading each relay settings in a loop — read all once before the loop.