### PR TITLE
UI adjustments

### DIFF
--- a/octoprint_octorelay/templates/octorelay_settings.jinja2
+++ b/octoprint_octorelay/templates/octorelay_settings.jinja2
@@ -156,7 +156,15 @@
                 <div class="control-group">
                     <label class="control-label">{{ _('OS Command') }} {{ _(state.upper()) }}</label>
                     <div class="controls">
-                        <input type="text" class="input-large" data-bind="value: cmd_{{state}}">
+                        <div class="input-prepend">
+                            <span class="add-on" style="font-family: monospace">$</span>
+                            <input
+                                type="text"
+                                class="input-xlarge"
+                                style="font-family: monospace;"
+                                data-bind="value: cmd_{{state}}"
+                            >
+                        </div>
                     </div>
                 </div>
                 {% endfor %}


### PR DESCRIPTION

Inputs for OS commands made with a monospace font.

<img width="481" alt="Screenshot 2023-08-11 at 09 15 29" src="https://github.com/borisbu/OctoRelay/assets/13189514/3c549c0e-fcef-4f19-94f1-f217ad9c0761">
