### PR TITLE
Organised logging

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -160,7 +160,7 @@ class OctoRelayPlugin(
         return flask.abort(400) # Unknown command
 
     def on_event(self, event, payload):
-        self._logger.debug(f"Received the {event} event having payload {payload}")
+        self._logger.debug(f"Received the {event} event having payload: {payload}")
         if event == Events.CLIENT_OPENED:
             self.update_ui()
         elif event == Events.PRINT_STARTED:

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -67,19 +67,16 @@ class OctoRelayPlugin(
         return ASSETS
 
     def on_after_startup(self):
-        self._logger.info("--------------------------------------------")
         self._logger.info("start OctoRelay")
         self.handle_plugin_event(STARTUP)
         self.update_ui()
         self.polling_timer = RepeatedTimer(POLLING_INTERVAL, self.input_polling, daemon=True)
         self.polling_timer.start()
         self._logger.info("OctoRelay plugin started")
-        self._logger.info("--------------------------------------------")
 
     def on_shutdown(self):
         self.polling_timer.cancel()
         self._logger.info("OctoRelay plugin stopped")
-        self._logger.info("--------------------------------------------")
 
     def get_api_commands(self):
         return {

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -48,7 +48,7 @@ class OctoRelayPlugin(
         return get_default_settings()
 
     def on_settings_save(self, data):
-        self._logger.info(f"Saving the settings {data}")
+        self._logger.info(f"Saving the settings: {data}")
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
         self.update_ui()
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -113,7 +113,7 @@ class OctoRelayPlugin(
                     "name": settings[index]["label_text"],
                     "active": relay.is_closed(),
                 })
-        self._logger.debug(f"Responding to {LIST_ALL_COMMAND}: {active_relays}")
+        self._logger.debug(f"Responding to {LIST_ALL_COMMAND} command: {active_relays}")
         return flask.jsonify(active_relays)
 
     def handle_get_status_command(self, index: str):

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -53,9 +53,9 @@ class OctoRelayPlugin(
 
     def on_settings_migrate(self, target: int, current):
         current = current or 0
-        self._logger.info(f"OctoRelay performs the migration of its settings from v{current} to v{target}")
+        self._logger.info(f"Performing the settings migration from v{current} to v{target}")
         migrate(current, self._settings, self._logger)
-        self._logger.info(f"OctoRelay finished the migration of settings to v{target}")
+        self._logger.info(f"Finished the settings migration to v{target}")
 
     def get_template_configs(self):
         return get_templates()
@@ -67,16 +67,16 @@ class OctoRelayPlugin(
         return ASSETS
 
     def on_after_startup(self):
-        self._logger.info("start OctoRelay")
+        self._logger.info("Starting the plugin")
         self.handle_plugin_event(STARTUP)
         self.update_ui()
         self.polling_timer = RepeatedTimer(POLLING_INTERVAL, self.input_polling, daemon=True)
         self.polling_timer.start()
-        self._logger.info("OctoRelay plugin started")
+        self._logger.info("The plugin started")
 
     def on_shutdown(self):
         self.polling_timer.cancel()
-        self._logger.info("OctoRelay plugin stopped")
+        self._logger.info("The plugin stopped")
 
     def get_api_commands(self):
         return {
@@ -217,7 +217,7 @@ class OctoRelayPlugin(
 
     def run_system_command(self, cmd):
         if cmd:
-            self._logger.info(f"OctoRelay runs system command: {cmd}")
+            self._logger.info(f"Running the system command: {cmd}")
             os.system(cmd)
 
     def get_upcoming_tasks(self, subjects):

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -55,7 +55,7 @@ class OctoRelayPlugin(
         current = current or 0
         self._logger.info(f"Performing the settings migration from v{current} to v{target}")
         migrate(current, self._settings, self._logger)
-        self._logger.info(f"Finished the settings migration to v{target}")
+        self._logger.debug(f"Finished the settings migration to v{target}")
 
     def get_template_configs(self):
         return get_templates()
@@ -72,7 +72,7 @@ class OctoRelayPlugin(
         self.update_ui()
         self.polling_timer = RepeatedTimer(POLLING_INTERVAL, self.input_polling, daemon=True)
         self.polling_timer.start()
-        self._logger.info("The plugin started")
+        self._logger.debug("The plugin started")
 
     def on_shutdown(self):
         self.polling_timer.cancel()
@@ -136,7 +136,7 @@ class OctoRelayPlugin(
         return flask.jsonify(status="ok")
 
     def on_api_command(self, command, data):
-        self._logger.debug(f"on_api_command {command}, parameters {data}")
+        self._logger.info(f"on_api_command {command}, parameters {data}")
         if command == LIST_ALL_COMMAND: # API command to get relay statuses
             return self.handle_list_all_command()
         if command == GET_STATUS_COMMAND: # API command to get relay status
@@ -217,7 +217,7 @@ class OctoRelayPlugin(
 
     def run_system_command(self, cmd):
         if cmd:
-            self._logger.info(f"Running the system command: {cmd}")
+            self._logger.debug(f"Running the system command: {cmd}")
             os.system(cmd)
 
     def get_upcoming_tasks(self, subjects):
@@ -262,7 +262,6 @@ class OctoRelayPlugin(
                     "deadline": int(upcoming[index].deadline * 1000) # ms for JS
                 }
             }
-        #self._logger.info(f"update ui with model {self.model}")
         self._plugin_manager.send_plugin_message(self._identifier, self.model)
 
     # pylint: disable=useless-return

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -123,7 +123,7 @@ class OctoRelayPlugin(
             int(settings["relay_pin"] or 0),
             bool(settings["inverted_output"])
         ).is_closed() if bool(settings["active"]) else False
-        self._logger.debug(f"Responding to {GET_STATUS_COMMAND}: {is_closed}")
+        self._logger.debug(f"Responding to {GET_STATUS_COMMAND} command: {is_closed}")
         return flask.jsonify(status=is_closed)
 
     def handle_update_command(self, index: str):
@@ -136,14 +136,14 @@ class OctoRelayPlugin(
             return flask.jsonify(status="error")
         self.toggle_relay(index)
         self.update_ui()
-        self._logger.debug(f"Responding to {UPDATE_COMMAND}")
+        self._logger.debug(f"Responding to {UPDATE_COMMAND} command")
         return flask.jsonify(status="ok")
 
     def handle_cancel_task_command(self, subject: str, target: bool, owner: str):
         self._logger.debug(f"Cancelling tasks from {owner} to switch the relay {subject} {'ON' if target else 'OFF'}")
         self.cancel_tasks(subject, USER_ACTION, target, owner)
         self.update_ui()
-        self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND}")
+        self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")
         return flask.jsonify(status="ok")
 
     def on_api_command(self, command, data):

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -256,7 +256,7 @@ class OctoRelayPlugin(
         )
 
     def update_ui(self):
-        self._logger.debug(f"Updating the UI")
+        self._logger.debug("Updating the UI")
         settings = self._settings.get([], merged=True) # expensive
         upcoming = self.get_upcoming_tasks(filter(
             lambda index: bool(settings[index]["active"]) and bool(settings[index]["show_upcoming"]),

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -48,6 +48,7 @@ class OctoRelayPlugin(
         return get_default_settings()
 
     def on_settings_save(self, data):
+        self._logger.info(f"Saving the settings {data}")
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
         self.update_ui()
 
@@ -75,6 +76,7 @@ class OctoRelayPlugin(
         self._logger.debug("The plugin started")
 
     def on_shutdown(self):
+        self._logger.debug("Stopping the plugin")
         self.polling_timer.cancel()
         self._logger.info("The plugin stopped")
 
@@ -97,6 +99,7 @@ class OctoRelayPlugin(
             return False
 
     def handle_list_all_command(self):
+        self._logger.debug("Collecting information on all the relay states")
         active_relays = []
         settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
@@ -110,33 +113,41 @@ class OctoRelayPlugin(
                     "name": settings[index]["label_text"],
                     "active": relay.is_closed(),
                 })
+        self._logger.debug(f"Responding to {LIST_ALL_COMMAND}: {active_relays}")
         return flask.jsonify(active_relays)
 
     def handle_get_status_command(self, index: str):
+        self._logger.debug(f"Getting the relay {index} state")
         settings = self._settings.get([index], merged=True) # expensive
         is_closed = Relay(
             int(settings["relay_pin"] or 0),
             bool(settings["inverted_output"])
         ).is_closed() if bool(settings["active"]) else False
+        self._logger.debug(f"Responding to {GET_STATUS_COMMAND}: {is_closed}")
         return flask.jsonify(status=is_closed)
 
     def handle_update_command(self, index: str):
+        self._logger.debug(f"Requested to switch the relay {index}")
         if not self.has_switch_permission():
+            self._logger.warn("Insufficient permissions")
             return flask.abort(403)
         if index not in RELAY_INDEXES:
-            self._logger.warn(f"Invalid relay index supplied {index}")
+            self._logger.warn(f"Invalid relay index supplied: {index}")
             return flask.jsonify(status="error")
         self.toggle_relay(index)
         self.update_ui()
+        self._logger.debug(f"Responding to {UPDATE_COMMAND}")
         return flask.jsonify(status="ok")
 
     def handle_cancel_task_command(self, subject: str, target: bool, owner: str):
+        self._logger.debug(f"Cancelling tasks from {owner} to switch the relay {subject} {'ON' if target else 'OFF'}")
         self.cancel_tasks(subject, USER_ACTION, target, owner)
         self.update_ui()
+        self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND}")
         return flask.jsonify(status="ok")
 
     def on_api_command(self, command, data):
-        self._logger.info(f"on_api_command {command}, parameters {data}")
+        self._logger.info(f"Received the API command {command} with parameters: {data}")
         if command == LIST_ALL_COMMAND: # API command to get relay statuses
             return self.handle_list_all_command()
         if command == GET_STATUS_COMMAND: # API command to get relay status
@@ -145,10 +156,11 @@ class OctoRelayPlugin(
             return self.handle_update_command(data["pin"])
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
             return self.handle_cancel_task_command(data["subject"], bool(data["target"]), data["owner"])
+        self._logger.warn(f"Unknown command {command}")
         return flask.abort(400) # Unknown command
 
     def on_event(self, event, payload):
-        self._logger.debug(f"Got event: {event}")
+        self._logger.debug(f"Received the {event} event having payload {payload}")
         if event == Events.CLIENT_OPENED:
             self.update_ui()
         elif event == Events.PRINT_STARTED:
@@ -159,6 +171,7 @@ class OctoRelayPlugin(
             self.handle_plugin_event(PRINTING_STOPPED)
         elif hasattr(Events, "CONNECTIONS_AUTOREFRESHED"): # Requires OctoPrint 1.9+
             if event == Events.CONNECTIONS_AUTOREFRESHED:
+                self._logger.debug("Connecting to the printer")
                 self._printer.connect()
         #elif event == Events.PRINT_CANCELLING:
             # self.print_stopped()
@@ -166,6 +179,7 @@ class OctoRelayPlugin(
             # self.print_stopped()
 
     def handle_plugin_event(self, event):
+        self._logger.debug(f"Handling the plugin event: {event}")
         settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
             if bool(settings[index]["active"]):
@@ -177,28 +191,32 @@ class OctoRelayPlugin(
                     if delay == 0:
                         self.toggle_relay(index, target)
                     else:
+                        self._logger.debug(f"Postponing the switching of the relay {index} by {delay}s")
                         task = Task(
                             subject = index, target = target, owner = event, delay = delay,
                             function = self.toggle_relay, args = [index, target]
                         )
                         self.tasks.append(task)
                         task.timer.start()
+                        self._logger.debug(f"The task registered: {task}")
 
     def toggle_relay(self, index, target: Optional[bool] = None):
         settings = self._settings.get([index], merged=True) # expensive
         if not bool(settings["active"]):
+            self._logger.debug(f"Refusing to switch the relay {index} since it's disabled")
             return
         pin = int(settings["relay_pin"] or 0)
         inverted = bool(settings["inverted_output"])
         relay = Relay(pin, inverted)
         self._logger.debug(
-            f"Toggling relay {index} on pin {pin}" if target is None else
+            f"Toggling the relay {index} on pin {pin}" if target is None else
             f"Turning the relay {index} {'ON' if target else 'OFF'} (pin {pin})"
         )
         cmd = settings["cmd_on" if relay.toggle(target) else "cmd_off"]
         self.run_system_command(cmd)
 
     def cancel_tasks(self, subject: str, initiator: str, target: Optional[bool] = None, owner: Optional[str] = None):
+        self._logger.debug(f"Cancelling tasks by request from {initiator} for relay {subject}")
         exceptions = CANCELLATION_EXCEPTIONS.get(initiator) or []
         def handler(task: Task):
             not_exception = task.owner not in exceptions
@@ -208,12 +226,13 @@ class OctoRelayPlugin(
             if same_subject and not_exception and same_target and same_owner:
                 try:
                     task.cancel_timer()
-                    self._logger.info(f"cancelled {task}")
+                    self._logger.info(f"Cancelled the task: {task}")
                 except Exception as exception:
-                    self._logger.warn(f"failed to cancel {task}, reason: {exception}")
+                    self._logger.warn(f"Failed to cancel {task}, reason: {exception}")
                 return False # exclude
             return True # include
         self.tasks = list(filter(handler, self.tasks))
+        self._logger.debug("The cancelled tasks removed from the registry")
 
     def run_system_command(self, cmd):
         if cmd:
@@ -221,6 +240,7 @@ class OctoRelayPlugin(
             os.system(cmd)
 
     def get_upcoming_tasks(self, subjects):
+        self._logger.debug(f"Finding the upcoming tasks for {subjects}")
         future_tasks = filter(
             lambda task: task.subject in subjects and task.deadline > time.time() + PREEMPTIVE_CANCELLATION_CUTOFF,
             self.tasks
@@ -236,6 +256,7 @@ class OctoRelayPlugin(
         )
 
     def update_ui(self):
+        self._logger.debug(f"Updating the UI")
         settings = self._settings.get([], merged=True) # expensive
         upcoming = self.get_upcoming_tasks(filter(
             lambda index: bool(settings[index]["active"]) and bool(settings[index]["show_upcoming"]),
@@ -262,10 +283,12 @@ class OctoRelayPlugin(
                     "deadline": int(upcoming[index].deadline * 1000) # ms for JS
                 }
             }
+        self._logger.debug(f"The UI feed: {self.model}")
         self._plugin_manager.send_plugin_message(self._identifier, self.model)
 
     # pylint: disable=useless-return
     def process_at_command(self, _comm, _phase, command, parameters, *args, **kwargs):
+        self._logger.info(f"Received @{AT_COMMAND} command with params: {parameters}")
         if command == AT_COMMAND:
             index = parameters
             if index in RELAY_INDEXES:

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -4,9 +4,9 @@ def v0(settings, logger):
     # First 4 relays used to have active=True
     for index in ["r1", "r2", "r3", "r4"]: # no references to constants
         before = settings.get([index]) # without defaults
-        logger.debug(f"relay {index} stored settings: {before}")
+        logger.debug(f"Relay {index} stored settings: {before}")
         if "active" not in before:
-            logger.debug("inserting active=True into it")
+            logger.debug("Inserting active=True into it")
             after = { **before, "active": True }
             settings.set([index], after)
 
@@ -27,13 +27,13 @@ def v1(settings, logger):
     for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]: # no references to constants
         before = settings.get([index]) # without defaults
         after = {}
-        logger.debug(f"relay {index} stored settings: {before}")
+        logger.debug(f"Relay {index} stored settings: {before}")
         for key, value in before.items():
             if key in replacements:
                 after[replacements[key]] = value
             else:
                 after[key] = value
-        logger.debug(f"replacing it with: {after}")
+        logger.debug(f"Replacing it with: {after}")
         settings.set([index], after)
 
 def v2(settings, logger):
@@ -43,7 +43,7 @@ def v2(settings, logger):
     for index in ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]: # no references to constants
         before = settings.get([index]) # without defaults
         after = {}
-        logger.debug(f"relay {index} stored settings: {before}")
+        logger.debug(f"Relay {index} stored settings: {before}")
         for key, value in before.items():
             if key not in removed:
                 after[key] = value
@@ -70,7 +70,7 @@ def v2(settings, logger):
                 "delay": int(before.get("auto_off_delay") or 0)
             }
         }
-        logger.debug(f"replacing it with: {after}")
+        logger.debug(f"Replacing it with: {after}")
         settings.set([index], after)
 
 # List of migration functions starting from v0->v1

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -80,5 +80,5 @@ def migrate(current: int, settings, logger):
     # Current version number corresponds to the list index to begin migrations from
     jobs = migrators[current::]
     for index, job in enumerate(jobs):
-        logger.info(f"OctoRelay migrates to settings v{current + index + 1}")
+        logger.info(f"Migrating to settings v{current + index + 1}")
         job(settings, logger)

--- a/octoprint_octorelay/migrations.py
+++ b/octoprint_octorelay/migrations.py
@@ -80,5 +80,5 @@ def migrate(current: int, settings, logger):
     # Current version number corresponds to the list index to begin migrations from
     jobs = migrators[current::]
     for index, job in enumerate(jobs):
-        logger.info(f"Migrating to settings v{current + index + 1}")
+        logger.info(f"Migrating the settings to v{current + index + 1}")
         job(settings, logger)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -299,11 +299,9 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Should run the migrations
         self.plugin_instance._settings.get = Mock(return_value={})
         self.plugin_instance.on_settings_migrate(1, None)
-        self.plugin_instance._logger.info.assert_any_call(
-            "OctoRelay performs the migration of its settings from v0 to v1"
-        )
+        self.plugin_instance._logger.info.assert_any_call("Performing the settings migration from v0 to v1")
         migrationsMock.migrate.assert_called_with(0, self.plugin_instance._settings, self.plugin_instance._logger)
-        self.plugin_instance._logger.info.assert_called_with("OctoRelay finished the migration of settings to v1")
+        self.plugin_instance._logger.info.assert_called_with("Finished the settings migration to v1")
 
     def test_get_template_configs(self):
         # Should return the plugin template configurations

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -301,7 +301,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.plugin_instance.on_settings_migrate(1, None)
         self.plugin_instance._logger.info.assert_any_call("Performing the settings migration from v0 to v1")
         migrationsMock.migrate.assert_called_with(0, self.plugin_instance._settings, self.plugin_instance._logger)
-        self.plugin_instance._logger.info.assert_called_with("Finished the settings migration to v1")
+        self.plugin_instance._logger.debug.assert_called_with("Finished the settings migration to v1")
 
     def test_get_template_configs(self):
         # Should return the plugin template configurations

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -650,7 +650,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         timerMock.cancel=Mock( side_effect=Exception("Caught!") )
         self.plugin_instance.cancel_tasks(subject = "r4", initiator = "PRINTING_STARTED")
         self.plugin_instance._logger.warn.assert_called_with(
-            "failed to cancel Task(r4,False,PRINTING_STOPPED,0), reason: Caught!"
+            "Failed to cancel Task(r4,False,PRINTING_STOPPED,0), reason: Caught!"
         )
         timerMock.reset_mock()
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -163,7 +163,7 @@ class TestMigrations(unittest.TestCase):
         )
         logger = Mock()
         migrate(0, settings, logger)
-        logger.info.assert_any_call("OctoRelay migrates to settings v1")
+        logger.info.assert_any_call("Migrating the settings to v1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #180 

### Reasoning

- General cleanup
- Consistency and neatness 
- Reducing the noise and the volume on the `info` (default) level
- Improve clarity and the volume on `debug` level (opt-in), making it easier to debug something if needed

### What's done

- [X] Removed horizontal lines from logs
- [X] No need to say `OctoRelay` since OctoPrint's log already has this information
- [x] Establishing the system of logging severity:
  - Starting and finishing the operation of the plugin — `info`
  - Beginnings of handlers of user actions — `info`
  - Clarifications on details or consequences of user actions — `debug`
  - Successful ending of an operation — `debug`
  - Beginning of a code branch (conditional code) — `debug`
  - General tracing — `debug`
- [x] Where logging is excessive and where it's missing?
- [x] Clarify of the messages