### PR TITLE
Removing the outside click listener for upcoming switch popover.

### DIFF
--- a/ts/octorelay.spec.ts
+++ b/ts/octorelay.spec.ts
@@ -246,35 +246,6 @@ describe("OctoRelayViewModel", () => {
     }
   );
 
-  test("Should display upcoming state popover (%s sec delay)", () => {
-    const handler = (registry[0].construct as OwnModel & OwnProperties)
-      .onDataUpdaterPluginMessage;
-    handler("octorelay", {
-      r1: {
-        relay_pin: 16,
-        inverted_output: false,
-        relay_state: true,
-        label_text: "Nozzle Light",
-        active: true,
-        icon_html: "<div>&#128161;</div>",
-        confirm_off: false,
-        upcoming: {
-          target: false,
-          owner: "PRINTING_STOPPED",
-          deadline: Date.now() + 20 * 1000,
-        },
-      },
-    });
-    expect(addEventListenerMock).toHaveBeenCalledWith(
-      "click",
-      expect.any(Function)
-    );
-    const listener = addEventListenerMock.mock.calls[0][1];
-    listener({ target: "targetMock" });
-    expect(elementMock.popover).toHaveBeenCalledWith("hide");
-    expect(removeEventListenerMock).toHaveBeenCalledWith("click", listener);
-  });
-
   test.each([true, false])("Should set countdown %#", (isVisible) => {
     const handler = (registry[0].construct as OwnModel & OwnProperties)
       .onDataUpdaterPluginMessage;
@@ -338,7 +309,7 @@ describe("OctoRelayViewModel", () => {
     });
   });
 
-  test("Clicking on Cancel button should send the command", () => {
+  test("Clicking on Close button should close the popover", () => {
     const handler = (registry[0].construct as OwnModel & OwnProperties)
       .onDataUpdaterPluginMessage;
     handler("octorelay", {

--- a/ts/octorelay.ts
+++ b/ts/octorelay.ts
@@ -102,19 +102,6 @@ $(() => {
       return `in ${formattedTimeLeft}`;
     };
 
-    const onClickOutside = (selector: JQuery, handler: () => void) => {
-      const listener = (event: MouseEvent) => {
-        const target = $(event.target!); // !
-        if (!target.closest(selector).length) {
-          if (selector.is(":visible")) {
-            handler();
-          }
-          document.removeEventListener("click", listener); // disposer
-        }
-      };
-      document.addEventListener("click", listener);
-    };
-
     const getCountdownDelay = (deadline: number): number =>
       deadline - Date.now() > 120000 ? 60000 : 1000;
 
@@ -182,13 +169,11 @@ $(() => {
             timeTag,
             value.upcoming.deadline
           );
-          const closePopover = () => {
+          closeBtn.on("click", () => {
             countdownDisposer();
             closeBtn.off("click");
             relayBtn.popover("hide");
-          };
-          closeBtn.on("click", closePopover);
-          onClickOutside(closeBtn.closest(".popover"), closePopover);
+          });
           cancelBtn.on("click", () => cancelPostponedTask(key, value));
         } else {
           relayBtn


### PR DESCRIPTION
Probably fixes #190 

This is the UX adjustment that removes the outside click listener from the popover, that might lead to confusion, making the popover disappear unexpectedly from the user's perspecive.