### PR TITLE
Disconnecting from the printer before when turning its relay off

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -219,7 +219,7 @@ class OctoRelayPlugin(
         if not bool(settings["active"]):
             self._logger.debug(f"Refusing to switch the relay {index} since it's disabled")
             return
-        if self.is_printer_relay(index):
+        if target is not True and self.is_printer_relay(index):
             self._logger.debug(f"{index} is the printer relay")
             if self._printer.is_operational():
                 self._logger.debug(f"Disconnecting from the printer before turning {index} OFF")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -505,6 +505,17 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "MockedIdentifier", expected_model
             )
 
+    def test_is_printer_relay(self):
+        cases = [
+            { "printer": "r4", "expected": True },
+            { "printer": "r5", "expected": False },
+            { "printer": None, "expected": False }
+        ]
+        for case in cases:
+            self.plugin_instance._settings.get = Mock(return_value=case["printer"])
+            actual = self.plugin_instance.is_printer_relay("r4")
+            self.assertEqual(actual, case["expected"])
+
     @patch("os.system")
     def test_toggle_relay(self, system_mock):
         # Should toggle the relay and execute a command matching its new state

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -567,9 +567,11 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_toggle_relay__printer(self):
         # Should disconnect from the printer when turning its relay off
         cases = [
-            { "is_printer": True, "is_operational": True },
-            { "is_printer": True, "is_operational": False },
-            { "is_printer": False, "is_operational": True },
+            { "target": None, "is_printer": True, "is_operational": True },
+            { "target": False, "is_printer": True, "is_operational": True },
+            { "target": True, "is_printer": True, "is_operational": True },
+            { "target": False, "is_printer": True, "is_operational": False },
+            { "target": False, "is_printer": False, "is_operational": True },
         ]
         self.plugin_instance._settings.get = Mock(return_value={
             "active": True,
@@ -583,8 +585,8 @@ class TestOctoRelayPlugin(unittest.TestCase):
             self.plugin_instance._printer.reset_mock()
             self.plugin_instance.is_printer_relay = Mock(return_value=case["is_printer"])
             self.plugin_instance._printer.is_operational = Mock(return_value=case["is_operational"])
-            self.plugin_instance.toggle_relay("r4")
-            if case["is_printer"] and case["is_operational"]:
+            self.plugin_instance.toggle_relay("r4", case["target"])
+            if case["target"] is not True and case["is_printer"] and case["is_operational"]:
                 self.plugin_instance._printer.disconnect.assert_called_with()
             else:
                 self.plugin_instance._printer.disconnect.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -568,21 +568,25 @@ class TestOctoRelayPlugin(unittest.TestCase):
         cases = [
             {
                 "event": Events.CLIENT_OPENED,
+                "payload": {"remoteAddress": "127.0.0.1"},
                 "expectedMethod": self.plugin_instance.update_ui,
                 "expectedParams": []
             },
             {
                 "event": Events.PRINT_STARTED,
+                "payload": {"name": "test.gcode"},
                 "expectedMethod": self.plugin_instance.handle_plugin_event,
                 "expectedParams": ["PRINTING_STARTED"]
             },
             {
                 "event": Events.PRINT_DONE,
+                "payload": {"name": "test.gcode"},
                 "expectedMethod": self.plugin_instance.handle_plugin_event,
                 "expectedParams": ["PRINTING_STOPPED"]
             },
             {
                 "event": Events.PRINT_FAILED,
+                "payload": {"name": "test.gcode"},
                 "expectedMethod": self.plugin_instance.handle_plugin_event,
                 "expectedParams": ["PRINTING_STOPPED"]
             },
@@ -590,11 +594,12 @@ class TestOctoRelayPlugin(unittest.TestCase):
         if hasattr(Events, "CONNECTIONS_AUTOREFRESHED"): # Requires OctoPrint 1.9+
             cases.append({
                 "event": Events.CONNECTIONS_AUTOREFRESHED,
+                "payload": {"ports": ["/dev/ttyUSB0"]},
                 "expectedMethod": self.plugin_instance._printer.connect,
                 "expectedParams": []
             })
         for case in cases:
-            self.plugin_instance.on_event(case["event"], "MockedPayload")
+            self.plugin_instance.on_event(case["event"], case["payload"])
             case["expectedMethod"].assert_called_with(*case["expectedParams"])
 
     def test_on_after_startup(self):
@@ -814,6 +819,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_handle_update_command(self, system_mock, jsonify_mock):
         # Should toggle the relay state, execute command and update UI when having permission
         self.plugin_instance.update_ui = Mock()
+        self.plugin_instance.is_printer_relay = Mock(return_value=False)
         cases = [
             {
                 "index": "r4",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -506,6 +506,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             )
 
     def test_is_printer_relay(self):
+        # Should assert the equality of the common/printer value with the supplied argument
         cases = [
             { "printer": "r4", "expected": True },
             { "printer": "r5", "expected": False },


### PR DESCRIPTION
Closes #153 

This feature makes the following improvements:
- it prevents the `SerialException` error appearance when turning the printer relay off,
- it prevents the redundant attempts to connect when there are no printers visible.