### PR TITLE
Ref: API: Moving response shaping out of handlers

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -137,10 +137,11 @@ class OctoRelayPlugin(
         self.update_ui()
         return state
 
-    def handle_cancel_task_command(self, subject: str, target: bool, owner: str):
+    def handle_cancel_task_command(self, subject: str, target: bool, owner: str) -> bool:
         self._logger.debug(f"Cancelling tasks from {owner} to switch the relay {subject} {'ON' if target else 'OFF'}")
-        self.cancel_tasks(subject, USER_ACTION, target, owner)
+        is_cancelled = self.cancel_tasks(subject, USER_ACTION, target, owner)
         self.update_ui()
+        return is_cancelled
 
     def on_api_command(self, command, data):
         self._logger.info(f"Received the API command {command} with parameters: {data}")

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -152,19 +152,19 @@ class OctoRelayPlugin(
         if command == GET_STATUS_COMMAND: # API command to get relay status
             is_closed = self.handle_get_status_command(data["pin"])
             self._logger.info(f"Responding to {GET_STATUS_COMMAND} command: {is_closed}")
-            return flask.jsonify(status=is_closed)
+            return flask.jsonify({"status": is_closed})
         if command == UPDATE_COMMAND: # API command to toggle the relay
             target = data.get("target")
             try:
                 state = self.handle_update_command(data["pin"], target if isinstance(target, bool) else None)
                 self._logger.debug(f"Responding to {UPDATE_COMMAND} command. Switched state to {state}")
-                flask.jsonify(status="ok", result=state)
+                return flask.jsonify({"status": "ok", "result": state})
             except Exception:
                 return flask.abort(400)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
             self.handle_cancel_task_command(data["subject"], bool(data["target"]), data["owner"])
             self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")
-            return flask.jsonify(status="ok")
+            return flask.jsonify({"status": "ok"})
         self._logger.warn(f"Unknown command {command}")
         return flask.abort(400) # Unknown command
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -137,7 +137,7 @@ class OctoRelayPlugin(
         try:
             state = self.toggle_relay(index, target) # can raise an Exception if relay is disabled
         except Exception as exception:
-            raise HandlingException(404) from exception
+            raise HandlingException(400) from exception
         self.update_ui()
         return state
 
@@ -163,8 +163,8 @@ class OctoRelayPlugin(
                 state = self.handle_update_command(data["pin"], target if isinstance(target, bool) else None)
                 self._logger.debug(f"Responding to {UPDATE_COMMAND} command. Switched state to {state}")
                 return flask.jsonify({"status": "ok", "result": state})
-            except HandlingException as exception: # todo: deprecate the behavior for 404, only abort in next version
-                return flask.jsonify({"status": "error"}) if exception.status == 404 else flask.abort(exception.status)
+            except HandlingException as exception: # todo: deprecate the behavior for 400, only abort in next version
+                return flask.jsonify({"status": "error"}) if exception.status == 400 else flask.abort(exception.status)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
             self.handle_cancel_task_command(data["subject"], bool(data["target"]), data["owner"])
             self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -115,54 +115,55 @@ class OctoRelayPlugin(
                     "name": settings[index]["label_text"],
                     "active": relay.is_closed(),
                 })
-        self._logger.debug(f"Responding to {LIST_ALL_COMMAND} command: {active_relays}")
-        return flask.jsonify(active_relays)
+        return active_relays
 
-    def handle_get_status_command(self, index: str):
+    def handle_get_status_command(self, index: str) -> bool:
         self._logger.debug(f"Getting the relay {index} state")
         settings = self._settings.get([index], merged=True) # expensive
-        is_closed = Relay(
+        return Relay(
             int(settings["relay_pin"] or 0),
             bool(settings["inverted_output"])
         ).is_closed() if bool(settings["active"]) else False
-        self._logger.debug(f"Responding to {GET_STATUS_COMMAND} command: {is_closed}")
-        return flask.jsonify(status=is_closed)
 
-    def handle_update_command(self, index: str, target: Optional[bool] = None):
+    def handle_update_command(self, index: str, target: Optional[bool] = None) -> bool:
         self._logger.debug(f"Requested to switch the relay {index} to {target}")
         if not self.has_switch_permission():
             self._logger.warn("Insufficient permissions")
-            return flask.abort(403)
+            raise Exception("Forbidden")
         if index not in RELAY_INDEXES:
             self._logger.warn(f"Invalid relay index supplied: {index}")
-            return flask.jsonify(status="error")
-        try:
-            state = self.toggle_relay(index, target)
-        except Exception as exception:
-            self._logger.warn(f"Failed to toggle the relay {index}, reason: {exception}")
-            return flask.jsonify(status="error", reason=f"Can not toggle the relay {index}")
+            raise Exception("Bad request")
+        state = self.toggle_relay(index, target) # can raise an Exception
         self.update_ui()
-        self._logger.debug(f"Responding to {UPDATE_COMMAND} command. Switched state to {state}")
-        return flask.jsonify(status="ok", result=state)
+        return state
 
     def handle_cancel_task_command(self, subject: str, target: bool, owner: str):
         self._logger.debug(f"Cancelling tasks from {owner} to switch the relay {subject} {'ON' if target else 'OFF'}")
         self.cancel_tasks(subject, USER_ACTION, target, owner)
         self.update_ui()
-        self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")
-        return flask.jsonify(status="ok")
 
     def on_api_command(self, command, data):
         self._logger.info(f"Received the API command {command} with parameters: {data}")
         if command == LIST_ALL_COMMAND: # API command to get relay statuses
-            return self.handle_list_all_command()
+            response = self.handle_list_all_command()
+            self._logger.info(f"Responding to {LIST_ALL_COMMAND} command: {response}")
+            return flask.jsonify(response)
         if command == GET_STATUS_COMMAND: # API command to get relay status
-            return self.handle_get_status_command(data["pin"])
+            is_closed = self.handle_get_status_command(data["pin"])
+            self._logger.info(f"Responding to {GET_STATUS_COMMAND} command: {is_closed}")
+            return flask.jsonify(status=is_closed)
         if command == UPDATE_COMMAND: # API command to toggle the relay
             target = data.get("target")
-            return self.handle_update_command(data["pin"], target if isinstance(target, bool) else None)
+            try:
+                state = self.handle_update_command(data["pin"], target if isinstance(target, bool) else None)
+                self._logger.debug(f"Responding to {UPDATE_COMMAND} command. Switched state to {state}")
+                flask.jsonify(status="ok", result=state)
+            except Exception:
+                return flask.abort(400)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
-            return self.handle_cancel_task_command(data["subject"], bool(data["target"]), data["owner"])
+            self.handle_cancel_task_command(data["subject"], bool(data["target"]), data["owner"])
+            self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")
+            return flask.jsonify(status="ok")
         self._logger.warn(f"Unknown command {command}")
         return flask.abort(400) # Unknown command
 
@@ -223,7 +224,8 @@ class OctoRelayPlugin(
     def toggle_relay(self, index, target: Optional[bool] = None) -> bool:
         settings = self._settings.get([index], merged=True) # expensive
         if not bool(settings["active"]):
-            raise Exception(f"Relay {index} is disabled")
+            self._logger.warn(f"Relay {index} is disabled")
+            raise Exception("Bad request")
         if target is not True and self.is_printer_relay(index):
             self._logger.debug(f"{index} is the printer relay")
             if self._printer.is_operational():

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -139,7 +139,7 @@ class OctoRelayPlugin(
             self.update_ui()
             return state
         except Exception as exception:
-            raise HandlingException(403) from exception
+            raise HandlingException(404) from exception
 
     def handle_cancel_task_command(self, subject: str, target: bool, owner: str) -> bool:
         self._logger.debug(f"Cancelling tasks from {owner} to switch the relay {subject} {'ON' if target else 'OFF'}")
@@ -163,8 +163,8 @@ class OctoRelayPlugin(
                 state = self.handle_update_command(data["pin"], target if isinstance(target, bool) else None)
                 self._logger.debug(f"Responding to {UPDATE_COMMAND} command. Switched state to {state}")
                 return flask.jsonify({"status": "ok", "result": state})
-            except HandlingException as exception:
-                return flask.abort(exception.status)
+            except HandlingException as exception: # todo: deprecate the behavior for 404, only abort in next version
+                return flask.jsonify({"status": "error"}) if exception.status == 404 else flask.abort(exception.status)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
             self.handle_cancel_task_command(data["subject"], bool(data["target"]), data["owner"])
             self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -137,8 +137,8 @@ class OctoRelayPlugin(
             self._logger.warn(f"Invalid relay index supplied: {index}")
             raise HandlingException(400)
         try:
-            state = self.toggle_relay(index, target) # can raise an Exception if relay is disabled
-        except Exception as exception:
+            state = self.toggle_relay(index, target)
+        except Exception as exception: # disabled relay
             raise HandlingException(400) from exception
         self.update_ui()
         return state

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -136,10 +136,10 @@ class OctoRelayPlugin(
             raise HandlingException(400)
         try:
             state = self.toggle_relay(index, target) # can raise an Exception if relay is disabled
-            self.update_ui()
-            return state
         except Exception as exception:
             raise HandlingException(404) from exception
+        self.update_ui()
+        return state
 
     def handle_cancel_task_command(self, subject: str, target: bool, owner: str) -> bool:
         self._logger.debug(f"Cancelling tasks from {owner} to switch the relay {subject} {'ON' if target else 'OFF'}")

--- a/octoprint_octorelay/exceptions.py
+++ b/octoprint_octorelay/exceptions.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+class HandlingException(Exception):
+    def __init__(self, status: int):
+        super().__init__()
+        self.status = status

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1028,6 +1028,13 @@ class TestOctoRelayPlugin(unittest.TestCase):
             case["expectedOutcome"].assert_called_with(case["expectedPayload"])
 
     @patch("flask.abort")
+    def test_on_api_command__exceptions(self, abort_mock):
+        # Should respond with a faulty HTTP code when handler raises
+        self.plugin_instance.handle_update_command = Mock(side_effect=Exception("Bad request"))
+        self.plugin_instance.on_api_command("update", {})
+        abort_mock.assert_called_with(400)
+
+    @patch("flask.abort")
     def test_on_api_command__unknown(self, abort_mock):
         # Should respond with status code 400 (bad request) to unknown commands
         self.plugin_instance.on_api_command("command", {})

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -819,8 +819,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             self.assertIs(actual, case["expected"])
         self.plugin_instance._logger.warn.assert_called_with("Failed to check relay switching permission, Caught!")
 
-    @patch("flask.jsonify")
-    def test_handle_list_all_command(self, jsonify_mock):
+    def test_handle_list_all_command(self):
         # Should respond with JSON having states of the active relays
         cases = [{
             "closed": False,
@@ -850,11 +849,12 @@ class TestOctoRelayPlugin(unittest.TestCase):
             self.plugin_instance._settings.get = Mock(return_value={
                 index: relay_settings_mock for index in RELAY_INDEXES
             })
-            self.plugin_instance.handle_list_all_command()
-            jsonify_mock.assert_called_with(case["expectedJson"])
+            self.assertEqual(
+                self.plugin_instance.handle_list_all_command(),
+                case["expectedJson"]
+            )
 
-    @patch("flask.jsonify")
-    def test_handle_get_status_command(self, jsonify_mock):
+    def test_handle_get_status_command(self):
         # Should respond with JSON having the requested relay state
         cases = [
             { "closed": False, "expectedStatus": False },
@@ -871,13 +871,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "cmd_off": "CommandOffMock"
             }
             self.plugin_instance._settings.get = Mock(return_value=relay_settings_mock)
-            self.plugin_instance.handle_get_status_command("r4")
+            self.assertEqual(
+                self.plugin_instance.handle_get_status_command("r4"),
+                case["expectedStatus"]
+            )
             self.plugin_instance._settings.get.assert_called_with(["r4"], merged=True)
-            jsonify_mock.assert_called_with(status=case["expectedStatus"])
 
-    @patch("flask.jsonify")
     @patch("os.system")
-    def test_handle_update_command(self, system_mock, jsonify_mock):
+    def test_handle_update_command(self, system_mock):
         # Should toggle the relay state, execute command and update UI when having permission
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.is_printer_relay = Mock(return_value=False)
@@ -886,7 +887,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "index": "r4",
                 "target": None,
                 "closed": False,
-                "expectedStatus": "ok",
+                "expectedError": False,
                 "expectedResult": True,
                 "expectedToggle": True,
                 "expectedCommand": "CommandOnMock",
@@ -896,7 +897,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "index": "r4",
                 "target": False,
                 "closed": True,
-                "expectedStatus": "ok",
+                "expectedError": False,
                 "expectedResult": False, # from the !closed returned by mocked Relay::toggle() below
                 "expectedToggle": True,
                 "expectedCommand": "CommandOffMock"
@@ -905,7 +906,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "index": "invalid",
                 "target": False,
                 "closed": True,
-                "expectedStatus": "error",
+                "expectedError": True,
             }
         ]
         for case in cases:
@@ -923,8 +924,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "cmd_off": "CommandOffMock"
             }
             self.plugin_instance._settings.get = Mock(return_value=relay_settings_mock)
-            self.plugin_instance.handle_update_command(case["index"], case["target"])
-            if case["expectedStatus"] != "error":
+            if case["expectedError"]:
+                with self.assertRaises(Exception, msg="Bad request"):
+                    self.plugin_instance.handle_update_command(case["index"], case["target"])
+            else:
+                self.assertEqual(
+                    self.plugin_instance.handle_update_command(case["index"], case["target"]),
+                    case["expectedResult"]
+                )
                 self.plugin_instance._settings.get.assert_called_with(["r4"], merged=True)
             if "expectedToggle" in case:
                 relayMock.toggle.assert_called_with(case["target"])
@@ -935,15 +942,8 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 self.plugin_instance.handle_plugin_event.assert_called_with(case["expectedEvent"], scope = ["r4"])
             else:
                 self.plugin_instance.handle_plugin_event.assert_not_called()
-            if "expectedStatus" in case:
-                if "expectedResult" in case:
-                    jsonify_mock.assert_called_with(status=case["expectedStatus"], result=case["expectedResult"])
-                else:
-                    jsonify_mock.assert_called_with(status=case["expectedStatus"])
 
-
-    @patch("flask.abort")
-    def test_handle_update_command__exception_permissions(self, abort_mock):
+    def test_handle_update_command__exception_permissions(self):
         # Should refuse to update the relay state in case of insufficient permissions
         self.plugin_instance._settings.get = Mock(return_value={
             "active": True,
@@ -953,12 +953,11 @@ class TestOctoRelayPlugin(unittest.TestCase):
             "cmd_off": "CommandOffMock"
         })
         permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=False)
-        self.plugin_instance.handle_update_command("r4")
+        with self.assertRaises(Exception, msg="Forbidden"):
+            self.plugin_instance.handle_update_command("r4")
         permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
-        abort_mock.assert_called_with(403)
 
-    @patch("flask.jsonify")
-    def test_handle_update_command__exception_disabled(self, jsonify_mock):
+    def test_handle_update_command__exception_disabled(self):
         # Should refuse to update the disabled relay
         self.plugin_instance._settings.get = Mock(return_value={
             "active": False,
@@ -968,53 +967,63 @@ class TestOctoRelayPlugin(unittest.TestCase):
             "cmd_off": "CommandOffMock"
         })
         permissionsMock.PLUGIN_OCTORELAY_SWITCH.can = Mock(return_value=True)
-        self.plugin_instance.handle_update_command("r4")
+        with self.assertRaises(Exception, msg="Bad request"):
+            self.plugin_instance.handle_update_command("r4")
         permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
-        jsonify_mock.assert_called_with(status="error", reason="Can not toggle the relay r4")
 
-    @patch("flask.jsonify")
-    def test_handle_cancel_task_command(self, jsonify_mock):
+    def test_handle_cancel_task_command(self):
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.cancel_tasks = Mock()
-        self.plugin_instance.handle_cancel_task_command("r4", True, "STARTUP")
+        self.assertTrue(
+            self.plugin_instance.handle_cancel_task_command("r4", True, "STARTUP")
+        )
         self.plugin_instance.cancel_tasks.assert_called_with("r4", "USER_ACTION", True, "STARTUP")
         self.plugin_instance.update_ui.assert_called_with()
-        jsonify_mock.assert_called_with(status="ok")
 
-    def test_on_api_command(self):
-        self.plugin_instance.handle_list_all_command = Mock()
-        self.plugin_instance.handle_get_status_command = Mock()
-        self.plugin_instance.handle_update_command = Mock()
-        self.plugin_instance.handle_cancel_task_command = Mock()
+    @patch("flask.jsonify")
+    def test_on_api_command(self, jsonify_mock):
+        self.plugin_instance.handle_list_all_command = Mock(return_value=[])
+        self.plugin_instance.handle_get_status_command = Mock(return_value=True)
+        self.plugin_instance.handle_update_command = Mock(return_value=False)
+        self.plugin_instance.handle_cancel_task_command = Mock(return_value=True)
         cases = [
             {
                 "command": "listAllStatus",
                 "data": {},
-                "expectedCall": self.plugin_instance.handle_list_all_command,
-                "expectedParams": []
+                "expectedMethod": self.plugin_instance.handle_list_all_command,
+                "expectedArguments": [],
+                "expectedOutcome": jsonify_mock,
+                "expectedPayload": [],
             },
             {
                 "command": "getStatus",
                 "data": { "pin": "r4" },
-                "expectedCall": self.plugin_instance.handle_get_status_command,
-                "expectedParams": ["r4"]
+                "expectedMethod": self.plugin_instance.handle_get_status_command,
+                "expectedArguments": ["r4"],
+                "expectedOutcome": jsonify_mock,
+                "expectedPayload": {"status": True},
             },
             {
                 "command": "update",
                 "data": { "pin": "r4", "target": True },
-                "expectedCall": self.plugin_instance.handle_update_command,
-                "expectedParams": ["r4", True]
+                "expectedMethod": self.plugin_instance.handle_update_command,
+                "expectedArguments": ["r4", True],
+                "expectedOutcome": jsonify_mock,
+                "expectedPayload": {"status": "ok", "result": False},
             },
             {
                 "command": "cancelTask",
                 "data": { "subject": "r4", "owner": "STARTUP", "target": True },
-                "expectedCall": self.plugin_instance.handle_cancel_task_command,
-                "expectedParams": [ "r4", True, "STARTUP" ]
+                "expectedMethod": self.plugin_instance.handle_cancel_task_command,
+                "expectedArguments": [ "r4", True, "STARTUP" ],
+                "expectedOutcome": jsonify_mock,
+                "expectedPayload": {"status": "ok"},
             }
         ]
         for case in cases:
             self.plugin_instance.on_api_command(case["command"], case["data"])
-            case["expectedCall"].assert_called_with(*case["expectedParams"])
+            case["expectedMethod"].assert_called_with(*case["expectedArguments"])
+            case["expectedOutcome"].assert_called_with(case["expectedPayload"])
 
     @patch("flask.abort")
     def test_on_api_command__unknown(self, abort_mock):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -879,6 +879,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             self.plugin_instance._settings.get.assert_called_with(["r4"], merged=True)
 
     def test_handle_get_status_command__exception(self):
+        # Should raise an Exception when requesting the state of disabled relay
         relay_settings_mock = {
             "active": False,
             "relay_pin": 17,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1057,7 +1057,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     @patch("flask.jsonify")
     def test_om_api_command__get_status_exception(self, jsonify_mock):
-        # Should respond with status false
+        # Should respond with status false when handler raises
         self.plugin_instance.handle_get_status_command = Mock(side_effect=HandlingException(400))
         self.plugin_instance.on_api_command("getStatus", {"pin": "r4"})
         jsonify_mock.assert_called_with({"status": False})

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -879,7 +879,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             self.plugin_instance._settings.get.assert_called_with(["r4"], merged=True)
 
     def test_handle_get_status_command__exception(self):
-        # Should raise an Exception when requesting the state of disabled relay
+        # Should raise when requesting the state of disabled relay
         relay_settings_mock = {
             "active": False,
             "relay_pin": 17,
@@ -959,7 +959,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 self.plugin_instance.handle_plugin_event.assert_not_called()
 
     def test_handle_update_command__exception_permissions(self):
-        # Should raise when attempting in case of insufficient permissions
+        # Should raise in case of insufficient permissions
         self.plugin_instance._settings.get = Mock(return_value={
             "active": True,
             "relay_pin": 17,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1034,7 +1034,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Should respond with a faulty HTTP code when handler raises
         cases = [
             { "status": 403, "expectedMethod": abort_mock, "expectedArgument": 403 },
-            { "status": 404, "expectedMethod": jsonify_mock, "expectedArgument": {"status": "error"} }
+            { "status": 400, "expectedMethod": jsonify_mock, "expectedArgument": {"status": "error"} }
         ]
         for case in cases:
             self.plugin_instance.handle_update_command = Mock(side_effect=HandlingException(case["status"]))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -820,7 +820,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         self.plugin_instance._logger.warn.assert_called_with("Failed to check relay switching permission, Caught!")
 
     def test_handle_list_all_command(self):
-        # Should respond with JSON having states of the active relays
+        # Should return the active relay states
         cases = [{
             "closed": False,
             "expectedJson": list(map(lambda index: {
@@ -855,7 +855,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
             )
 
     def test_handle_get_status_command(self):
-        # Should respond with JSON having the requested relay state
+        # Should return the relay state
         cases = [
             { "closed": False, "expectedStatus": False },
             { "closed": True, "expectedStatus": True }
@@ -879,7 +879,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     @patch("os.system")
     def test_handle_update_command(self, system_mock):
-        # Should toggle the relay state, execute command and update UI when having permission
+        # Should toggle the relay state, execute command, update UI and return the resulting state
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.is_printer_relay = Mock(return_value=False)
         cases = [
@@ -944,7 +944,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 self.plugin_instance.handle_plugin_event.assert_not_called()
 
     def test_handle_update_command__exception_permissions(self):
-        # Should refuse to update the relay state in case of insufficient permissions
+        # Should raise when attempting in case of insufficient permissions
         self.plugin_instance._settings.get = Mock(return_value={
             "active": True,
             "relay_pin": 17,
@@ -958,7 +958,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
 
     def test_handle_update_command__exception_disabled(self):
-        # Should refuse to update the disabled relay
+        # Should raise when attempting to update a disabled relay
         self.plugin_instance._settings.get = Mock(return_value={
             "active": False,
             "relay_pin": 17,
@@ -972,6 +972,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
         permissionsMock.PLUGIN_OCTORELAY_SWITCH.can.assert_called_with()
 
     def test_handle_cancel_task_command(self):
+        # Should return boolean indicating that the task was cancelled
         self.plugin_instance.update_ui = Mock()
         self.plugin_instance.cancel_tasks = Mock()
         self.assertTrue(
@@ -982,6 +983,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
 
     @patch("flask.jsonify")
     def test_on_api_command(self, jsonify_mock):
+        # Should call a handler and respond with expected payload
         self.plugin_instance.handle_list_all_command = Mock(return_value=[])
         self.plugin_instance.handle_get_status_command = Mock(return_value=True)
         self.plugin_instance.handle_update_command = Mock(return_value=False)


### PR DESCRIPTION
Contributes to #164 

No breaking changes to the API yet, but preparing for introducing its new version by extracting the response shaping outta handlers. So the `on_api_command` method will be the only one who operates `flask`.

Handlers, on the other hand, are either return data OR raise exceptions.

For that, introducing also `HandlingException` class, accepting the HTTP status code that is supposed to be used for managing the response in case of an error raised during handling the request.

Preserving (for now) the original behaviour of `update` command, which in case of disabled relay responds with `status: error` instead of aborting.

<!--
| Method | Inputs before | Inputs after | Outputs before | Outputs after |
|--------|--------|--------|--------|--------|
| update | pin, target | ... | result, status | ... |
| getStatus | pin | ... | status | ... |
| listAllStatus | | | active, id, name | ... | 
| cancelTask | subject, target, owner | ... | status | ... |
-->