### PR TITLE
Feat: API v2

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -152,30 +152,32 @@ class OctoRelayPlugin(
     def on_api_command(self, command, data):
         # pylint: disable=too-many-return-statements
         self._logger.info(f"Received the API command {command} with parameters: {data}")
-        index = data.get("pin")
-        if command in [GET_STATUS_COMMAND, UPDATE_COMMAND] and index is None:
-            return flask.abort(400, description="Parameter pin is missing")
+        version = data.get("version") or data.get("v") or 1;
+        subject_param_name = "pin" if version == 1 else "subject"
+        subject = data.get(subject_param_name)
+        target = data.get("target")
+        if command in [GET_STATUS_COMMAND, UPDATE_COMMAND] and subject is None:
+            return flask.abort(400, description=f"Parameter {subject_param_name} is missing")
         if command == LIST_ALL_COMMAND: # API command to get relay statuses
             response = self.handle_list_all_command()
             self._logger.info(f"Responding to {LIST_ALL_COMMAND} command: {response}")
             return flask.jsonify(response)
         if command == GET_STATUS_COMMAND: # API command to get relay status
             try:
-                is_closed = self.handle_get_status_command(index)
+                is_closed = self.handle_get_status_command(subject)
             except HandlingException:
                 is_closed = False # todo should just abort in the next version
             self._logger.info(f"Responding to {GET_STATUS_COMMAND} command: {is_closed}")
             return flask.jsonify({"status": is_closed})
         if command == UPDATE_COMMAND: # API command to toggle the relay
-            target = data.get("target")
             try:
-                state = self.handle_update_command(index, target if isinstance(target, bool) else None)
+                state = self.handle_update_command(subject, target if isinstance(target, bool) else None)
                 self._logger.debug(f"Responding to {UPDATE_COMMAND} command. Switched state to {state}")
                 return flask.jsonify({"status": "ok", "result": state})
             except HandlingException as exception: # todo: deprecate the behavior for 400, only abort in next version
                 return flask.jsonify({"status": "error"}) if exception.status == 400 else flask.abort(exception.status)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
-            self.handle_cancel_task_command(data["subject"], bool(data["target"]), data["owner"])
+            self.handle_cancel_task_command(data.get("subject"), bool(target), data["owner"]) # use subject after dropping v1
             self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")
             return flask.jsonify({"status": "ok"})
         self._logger.warn(f"Unknown command {command}")

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -158,7 +158,7 @@ class OctoRelayPlugin(
         target = data.get("target")
         if command in [GET_STATUS_COMMAND, UPDATE_COMMAND] and subject is None:
             return flask.abort(400, description=f"Parameter {subject_param_name} is missing")
-        # API command to get relay statuses
+        # API command to list all the relays with their names and statuses
         if command == LIST_ALL_COMMAND:
             relays = self.handle_list_all_command()
             response = list(map(lambda item: {

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -152,7 +152,7 @@ class OctoRelayPlugin(
     def on_api_command(self, command, data):
         # pylint: disable=too-many-return-statements
         self._logger.info(f"Received the API command {command} with parameters: {data}")
-        version = data.get("version") or data.get("v") or 1
+        version = int( data.get("version") or data.get("v") or 1 )
         subject_param_name = "pin" if version == 1 else "subject"
         subject = data.get(subject_param_name)
         target = data.get("target")

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -19,6 +19,7 @@ from .const import (
 )
 from .driver import Relay
 from .task import Task
+from .listing import Listing
 from .migrations import migrate
 from .model import Model, get_initial_model
 from .exceptions import HandlingException
@@ -101,9 +102,9 @@ class OctoRelayPlugin(
             self._logger.warn(f"Failed to check relay switching permission, {exception}")
             return False
 
-    def handle_list_all_command(self):
+    def handle_list_all_command(self) -> Listing:
         self._logger.debug("Collecting information on all the relay states")
-        active_relays = []
+        active_relays: Listing = []
         settings = self._settings.get([], merged=True) # expensive
         for index in RELAY_INDEXES:
             if bool(settings[index]["active"]):

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -178,14 +178,14 @@ class OctoRelayPlugin(
                 return flask.jsonify({"status": "ok", "result": state})
             except HandlingException as exception: # todo: deprecate the behavior for 400, only abort in next version
                 if version == 1 and exception.status == 400:
-                    return flask.jsonify({"status": "error"})
+                    return flask.jsonify({ "status": "error" })
                 return flask.abort(exception.status)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
-            self.handle_cancel_task_command(
+            cancelled = self.handle_cancel_task_command(
                 data.get("subject"), bool(target), data["owner"] # todo use subject after dropping v1
             )
-            self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")
-            return flask.jsonify({"status": "ok"})
+            self._logger.debug(f"Responding {cancelled} to {CANCEL_TASK_COMMAND} command")
+            return flask.jsonify({ "status": "ok" } if version == 1 else { "cancelled": cancelled })
         self._logger.warn(f"Unknown command {command}")
         return flask.abort(400, description="Unknown command")
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -158,7 +158,8 @@ class OctoRelayPlugin(
         target = data.get("target")
         if command in [GET_STATUS_COMMAND, UPDATE_COMMAND] and subject is None:
             return flask.abort(400, description=f"Parameter {subject_param_name} is missing")
-        if command == LIST_ALL_COMMAND: # API command to get relay statuses
+        # API command to get relay statuses
+        if command == LIST_ALL_COMMAND:
             relays = self.handle_list_all_command()
             response = list(map(lambda item: {
                 "id": item["id"],
@@ -167,7 +168,8 @@ class OctoRelayPlugin(
             }, relays)) if version == 1 else relays # todo remove ternary branch when dropping v1
             self._logger.info(f"Responding {response} to {LIST_ALL_COMMAND} command")
             return flask.jsonify(response)
-        if command == GET_STATUS_COMMAND: # API command to get relay status
+        # API command to get relay status
+        if command == GET_STATUS_COMMAND:
             try:
                 is_closed = self.handle_get_status_command(subject)
             except HandlingException as exception:
@@ -176,7 +178,8 @@ class OctoRelayPlugin(
                 is_closed = False # todo remove this when dropping v1
             self._logger.info(f"Responding {is_closed} to {GET_STATUS_COMMAND} command")
             return flask.jsonify({ "status": is_closed })
-        if command == UPDATE_COMMAND: # API command to toggle the relay
+        # API command to toggle the relay
+        if command == UPDATE_COMMAND:
             try:
                 state = self.handle_update_command(subject, target if isinstance(target, bool) else None)
                 self._logger.debug(f"Responding {state} to {UPDATE_COMMAND} command")
@@ -187,7 +190,8 @@ class OctoRelayPlugin(
                 if version == 1 and exception.status == 400:
                     return flask.jsonify({ "status": "error" }) # todo remove this branch when dropping v1
                 return flask.abort(exception.status)
-        if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
+        # API command to cancel the postponed toggling task
+        if command == CANCEL_TASK_COMMAND:
             cancelled = self.handle_cancel_task_command(
                 data.get("subject"), bool(target), data["owner"] # todo use subject after dropping v1
             )
@@ -195,7 +199,8 @@ class OctoRelayPlugin(
             if version == 1:
                 return flask.jsonify({ "status": "ok" }) # todo remove this branch when dropping v1
             return flask.jsonify({ "cancelled": cancelled })
-        self._logger.warn(f"Unknown command {command}")
+        # Unknown commands
+        self._logger.warn(f"Received unknown API command {command}")
         return flask.abort(400, description="Unknown command")
 
     def on_event(self, event, payload):

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -153,7 +153,7 @@ class OctoRelayPlugin(
         # pylint: disable=too-many-return-statements
         self._logger.info(f"Received the API command {command} with parameters: {data}")
         version = int( data.get("version") or data.get("v") or 1 )
-        subject_param_name = "pin" if version == 1 else "subject"
+        subject_param_name = "pin" if version == 1 else "subject" # todo remove pin when dropping v1
         subject = data.get(subject_param_name)
         target = data.get("target")
         if command in [GET_STATUS_COMMAND, UPDATE_COMMAND] and subject is None:

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -169,8 +169,8 @@ class OctoRelayPlugin(
                 if version > 1: # todo remove condition when dropping v1
                     return flask.abort(exception.status)
                 is_closed = False # todo remove this when dropping v1
-            self._logger.info(f"Responding to {GET_STATUS_COMMAND} command: {is_closed}")
-            return flask.jsonify({"status": is_closed})
+            self._logger.info(f"Responding {is_closed} to {GET_STATUS_COMMAND} command")
+            return flask.jsonify({ "status": is_closed })
         if command == UPDATE_COMMAND: # API command to toggle the relay
             try:
                 state = self.handle_update_command(subject, target if isinstance(target, bool) else None)

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -112,7 +112,7 @@ class OctoRelayPlugin(
                     bool(settings[index]["inverted_output"])
                 )
                 active_relays.append({
-                    "index": index,
+                    "id": index,
                     "name": settings[index]["label_text"],
                     "status": relay.is_closed(),
                 })
@@ -161,7 +161,7 @@ class OctoRelayPlugin(
         if command == LIST_ALL_COMMAND: # API command to get relay statuses
             relays = self.handle_list_all_command()
             response = list(map(lambda item: {
-                "id": item["index"],
+                "id": item["id"],
                 "name": item["name"],
                 "active": item["status"]
             }, relays)) if version == 1 else relays # todo remove ternary branch when dropping v1

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -175,7 +175,9 @@ class OctoRelayPlugin(
             try:
                 state = self.handle_update_command(subject, target if isinstance(target, bool) else None)
                 self._logger.debug(f"Responding to {UPDATE_COMMAND} command. Switched state to {state}")
-                return flask.jsonify({"status": "ok", "result": state})
+                if version == 1:
+                    return flask.jsonify({ "status": "ok", "result": state }) # todo remove branch when dropping v1
+                return flask.jsonify({ "status": state })
             except HandlingException as exception: # todo: deprecate the behavior for 400, only abort in next version
                 if version == 1 and exception.status == 400:
                     return flask.jsonify({ "status": "error" }) # todo remove this branch when dropping v1

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -152,7 +152,7 @@ class OctoRelayPlugin(
     def on_api_command(self, command, data):
         # pylint: disable=too-many-return-statements
         self._logger.info(f"Received the API command {command} with parameters: {data}")
-        version = data.get("version") or data.get("v") or 1;
+        version = data.get("version") or data.get("v") or 1
         subject_param_name = "pin" if version == 1 else "subject"
         subject = data.get(subject_param_name)
         target = data.get("target")
@@ -181,7 +181,9 @@ class OctoRelayPlugin(
                     return flask.jsonify({"status": "error"})
                 return flask.abort(exception.status)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
-            self.handle_cancel_task_command(data.get("subject"), bool(target), data["owner"]) # todo use subject after dropping v1
+            self.handle_cancel_task_command(
+                data.get("subject"), bool(target), data["owner"] # todo use subject after dropping v1
+            )
             self._logger.debug(f"Responding to {CANCEL_TASK_COMMAND} command")
             return flask.jsonify({"status": "ok"})
         self._logger.warn(f"Unknown command {command}")

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -170,12 +170,12 @@ class OctoRelayPlugin(
             return flask.jsonify(response)
         # API command to get relay status
         if command == GET_STATUS_COMMAND:
+            is_closed = False # todo remove this when dropping v1
             try:
                 is_closed = self.handle_get_status_command(subject)
             except HandlingException as exception:
-                if version > 1: # todo remove condition when dropping v1
+                if version != 1: # todo remove condition when dropping v1
                     return flask.abort(exception.status)
-                is_closed = False # todo remove this when dropping v1
             self._logger.info(f"Responding {is_closed} to {GET_STATUS_COMMAND} command")
             return flask.jsonify({ "status": is_closed })
         # API command to toggle the relay

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -178,14 +178,16 @@ class OctoRelayPlugin(
                 return flask.jsonify({"status": "ok", "result": state})
             except HandlingException as exception: # todo: deprecate the behavior for 400, only abort in next version
                 if version == 1 and exception.status == 400:
-                    return flask.jsonify({ "status": "error" })
+                    return flask.jsonify({ "status": "error" }) # todo remove this branch when dropping v1
                 return flask.abort(exception.status)
         if command == CANCEL_TASK_COMMAND: # API command to cancel the postponed toggling task
             cancelled = self.handle_cancel_task_command(
                 data.get("subject"), bool(target), data["owner"] # todo use subject after dropping v1
             )
             self._logger.debug(f"Responding {cancelled} to {CANCEL_TASK_COMMAND} command")
-            return flask.jsonify({ "status": "ok" } if version == 1 else { "cancelled": cancelled })
+            if version == 1:
+                return flask.jsonify({ "status": "ok" }) # todo remove this branch when dropping v1
+            return flask.jsonify({ "cancelled": cancelled })
         self._logger.warn(f"Unknown command {command}")
         return flask.abort(400, description="Unknown command")
 

--- a/octoprint_octorelay/listing.py
+++ b/octoprint_octorelay/listing.py
@@ -3,7 +3,9 @@ from typing import List
 # todo after dropping 3.7 take TypedDict from typing instead
 from typing_extensions import TypedDict
 
-
+# false positive, see https://github.com/pylint-dev/pylint/issues/4166
+# pylint: disable=too-many-ancestors
+# pylint: disable=too-few-public-methods
 class Element(TypedDict):
     id: str
     name: str

--- a/octoprint_octorelay/listing.py
+++ b/octoprint_octorelay/listing.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from typing import List
+# todo after dropping 3.7 take TypedDict from typing instead
+from typing_extensions import TypedDict
+
+
+class Element(TypedDict):
+    id: str
+    name: str
+    status: bool
+
+Listing = List[Element]

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ plugin_url = "https://github.com/borisbu/OctoRelay"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-# todo after dropping 3.7 remove typing-extensions (used by model.py)
+# todo after dropping 3.7 remove typing-extensions (used by model.py and listing.py)
 plugin_requires = ["RPi.GPIO", "typing-extensions"]
 
 # --------------------------------------------------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -999,7 +999,9 @@ class TestOctoRelayPlugin(unittest.TestCase):
     @patch("flask.jsonify")
     def test_on_api_command(self, jsonify_mock):
         # Should call a handler and respond with expected payload
-        self.plugin_instance.handle_list_all_command = Mock(return_value=[{"index": "r1", "name": "Test", "status": True}])
+        self.plugin_instance.handle_list_all_command = Mock(return_value=[
+            {"index": "r1", "name": "Test", "status": True}
+        ])
         self.plugin_instance.handle_get_status_command = Mock(return_value=True)
         self.plugin_instance.handle_update_command = Mock(return_value=False)
         self.plugin_instance.handle_cancel_task_command = Mock(return_value=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -825,14 +825,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
         cases = [{
             "closed": False,
             "expectedJson": list(map(lambda index: {
-                "index": index,
+                "id": index,
                 "name": "TEST",
                 "status": False
             }, RELAY_INDEXES))
         }, {
             "closed": True,
             "expectedJson": list(map(lambda index: {
-                "index": index,
+                "id": index,
                 "name": "TEST",
                 "status": True
             }, RELAY_INDEXES))
@@ -1000,7 +1000,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
     def test_on_api_command(self, jsonify_mock):
         # Should call a handler and respond with expected payload
         self.plugin_instance.handle_list_all_command = Mock(return_value=[
-            {"index": "r1", "name": "Test", "status": True}
+            {"id": "r1", "name": "Test", "status": True}
         ])
         self.plugin_instance.handle_get_status_command = Mock(return_value=True)
         self.plugin_instance.handle_update_command = Mock(return_value=False)
@@ -1020,7 +1020,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "expectedMethod": self.plugin_instance.handle_list_all_command,
                 "expectedArguments": [],
                 "expectedOutcome": jsonify_mock,
-                "expectedPayload": [{"index": "r1", "name": "Test", "status": True}],
+                "expectedPayload": [{"id": "r1", "name": "Test", "status": True}],
             },
             {
                 "command": "getStatus",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1051,6 +1051,14 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "expectedArguments": [ "r4", True, "STARTUP" ],
                 "expectedOutcome": jsonify_mock,
                 "expectedPayload": {"status": "ok"},
+            },
+            {
+                "command": "cancelTask",
+                "data": { "v": 2, "subject": "r4", "owner": "STARTUP", "target": True },
+                "expectedMethod": self.plugin_instance.handle_cancel_task_command,
+                "expectedArguments": [ "r4", True, "STARTUP" ],
+                "expectedOutcome": jsonify_mock,
+                "expectedPayload": {"cancelled": True},
             }
         ]
         for case in cases:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -825,16 +825,16 @@ class TestOctoRelayPlugin(unittest.TestCase):
         cases = [{
             "closed": False,
             "expectedJson": list(map(lambda index: {
-                "id": index,
+                "index": index,
                 "name": "TEST",
-                "active": False
+                "status": False
             }, RELAY_INDEXES))
         }, {
             "closed": True,
             "expectedJson": list(map(lambda index: {
-                "id": index,
+                "index": index,
                 "name": "TEST",
-                "active": True
+                "status": True
             }, RELAY_INDEXES))
         }]
         for case in cases:
@@ -999,7 +999,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
     @patch("flask.jsonify")
     def test_on_api_command(self, jsonify_mock):
         # Should call a handler and respond with expected payload
-        self.plugin_instance.handle_list_all_command = Mock(return_value=[])
+        self.plugin_instance.handle_list_all_command = Mock(return_value=[{"index": "r1", "name": "Test", "status": True}])
         self.plugin_instance.handle_get_status_command = Mock(return_value=True)
         self.plugin_instance.handle_update_command = Mock(return_value=False)
         self.plugin_instance.handle_cancel_task_command = Mock(return_value=True)
@@ -1010,7 +1010,15 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "expectedMethod": self.plugin_instance.handle_list_all_command,
                 "expectedArguments": [],
                 "expectedOutcome": jsonify_mock,
-                "expectedPayload": [],
+                "expectedPayload": [{"id": "r1", "name": "Test", "active": True}],
+            },
+            {
+                "command": "listAllStatus",
+                "data": {"v": 2},
+                "expectedMethod": self.plugin_instance.handle_list_all_command,
+                "expectedArguments": [],
+                "expectedOutcome": jsonify_mock,
+                "expectedPayload": [{"index": "r1", "name": "Test", "status": True}],
             },
             {
                 "command": "getStatus",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1042,7 +1042,7 @@ class TestOctoRelayPlugin(unittest.TestCase):
                 "expectedMethod": self.plugin_instance.handle_update_command,
                 "expectedArguments": ["r4", True],
                 "expectedOutcome": jsonify_mock,
-                "expectedPayload": {"status": "ok", "result": False},
+                "expectedPayload": {"status": False},
             },
             {
                 "command": "cancelTask",

--- a/ts/helpers/actions.spec.ts
+++ b/ts/helpers/actions.spec.ts
@@ -30,7 +30,8 @@ describe("Actions", () => {
         upcoming: null,
       });
       expect(apiMock).toHaveBeenCalledWith("octorelay", "update", {
-        pin: "r1",
+        v: 2,
+        subject: "r1",
       });
     });
 
@@ -56,7 +57,8 @@ describe("Actions", () => {
       elementMock.modal.mockClear();
       elementMock.on.mock.calls[1][1](); // confirm
       expect(apiMock).toHaveBeenCalledWith("octorelay", "update", {
-        pin: "r2",
+        v: 2,
+        subject: "r2",
       });
       expect(elementMock.modal).toHaveBeenCalledWith("hide");
     });
@@ -70,6 +72,7 @@ describe("Actions", () => {
         deadline: 86400,
       });
       expect(apiMock).toHaveBeenCalledWith("octorelay", "cancelTask", {
+        v: 2,
         owner: "PRINTING_STARTED",
         subject: "r2",
         target: true,

--- a/ts/helpers/actions.ts
+++ b/ts/helpers/actions.ts
@@ -3,7 +3,7 @@ import { ownCode } from "./const";
 
 export const toggleRelay = (key: string, relay: Relay) => {
   const command = () =>
-    OctoPrint.simpleApiCommand(ownCode, "update", { pin: key });
+    OctoPrint.simpleApiCommand(ownCode, "update", { v: 2, subject: key });
   if (!relay.confirm_off) {
     return command();
   }
@@ -28,6 +28,7 @@ export const toggleRelay = (key: string, relay: Relay) => {
 
 export const cancelTask = (key: string, { owner, target }: Task) =>
   OctoPrint.simpleApiCommand(ownCode, "cancelTask", {
+    v: 2,
     subject: key,
     owner,
     target,


### PR DESCRIPTION
Closes #164 

Introducing API parameter `version` or `v` (optional).
The default `version` falls back to `1` so the API keeps its original behaviour by default until the next major release.

## Changes of version 2

- When requesting an action on relay, now calling it `subject` instead of `pin`.
- When receiving the relay state, now calling it `status` instead of `result` or `active`.
- When requesting the state of disabled relay now responding with `400` HTTP code instead of `status: False`
- When updating or cancelling something, there is no more `status: "ok" | "error"`, the `status` now always means the relay state (boolean), while error response is supplied via HTTP code.

### Inputs

| Method | Inputs before | Inputs after |
|--------|--------|--------|
| update | `pin, target` | `subject, target` |
| getStatus | `pin` | `subject` |
| listAllStatus | — | — | 
| cancelTask | `subject, target, owner` | `subject, target, owner` |

### Outputs

| Method | Outputs before | Outputs after |
|--------|--------|--------|
| update | `result: bool, status: ok` | `status: bool` |
| getStatus | `status` | `status` |
| listAllStatus | `[active, id, name]` | `[status, id, name]` | 
| cancelTask | `status: ok` | `cancelled: bool` |
