### PR TITLE
Prevent installations on environments having unsupported Python versions

### DIFF
--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -371,7 +371,6 @@ class OctoRelayPlugin(
                 self.update_ui()
                 break
 
-__plugin_pythoncompat__ = ">=3.9,<4"
 __plugin_implementation__ = OctoRelayPlugin()
 
 __plugin_hooks__ = {
@@ -384,4 +383,4 @@ __plugin_hooks__ = {
 }
 
 # pylint: disable=wrong-import-position
-from ._version import __version__
+from ._version import __version__, __plugin_pythoncompat__

--- a/octoprint_octorelay/_version.py
+++ b/octoprint_octorelay/_version.py
@@ -148,7 +148,7 @@ def get_version_from_git_archive(version_info):
 
 
 __version__ = get_version()
-
+__plugin_pythoncompat__ = ">=3.9,<4"
 
 # The following section defines a 'get_cmdclass' function
 # that can be used from setup.py. The '__version__' module

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,6 @@ setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
 
 if len(additional_setup_parameters):
     from octoprint.util import dict_merge
-    setup_parameters = dict_merge(
-        setup_parameters, additional_setup_parameters)
+    setup_parameters = dict_merge(setup_parameters, additional_setup_parameters)
 
 setup(**setup_parameters)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = { python_requires: ">=3.9,<4" }
+additional_setup_parameters = { "python_requires": ">=3.9,<4" }
 
 ########################################################################################################################
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = { python_requires: ">=3.9,<4" }
 
 ########################################################################################################################
 
@@ -100,7 +100,6 @@ setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
     mail=plugin_author_email,
     url=plugin_url,
     license=plugin_license,
-    python_requires=">=3.9,<4",
     requires=plugin_requires,
     additional_packages=plugin_additional_packages,
     ignored_packages=plugin_ignored_packages,

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
     mail=plugin_author_email,
     url=plugin_url,
     license=plugin_license,
-    python_requires=">=3.9,<4"
+    python_requires=">=3.9,<4",
     requires=plugin_requires,
     additional_packages=plugin_additional_packages,
     ignored_packages=plugin_ignored_packages,

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ def get_version_and_cmdclass(pkg_path):
     spec = spec_from_file_location("version", os.path.join(pkg_path, "_version.py"))
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module.__version__, module.get_cmdclass(pkg_path)
+    return module.__version__, module.__plugin_pythoncompat__, module.get_cmdclass(pkg_path)
 
-miniver_version, cmdclass = get_version_and_cmdclass(r"octoprint_octorelay")
+miniver_version, python_compatibility, cmdclass = get_version_and_cmdclass(r"octoprint_octorelay")
 
 ########################################################################################################################
 # Do not forget to adjust the following variables to your own plugin.
@@ -76,7 +76,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = { "python_requires": ">=3.9,<4" }
+additional_setup_parameters = { "python_requires": python_compatibility }
 
 ########################################################################################################################
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
     mail=plugin_author_email,
     url=plugin_url,
     license=plugin_license,
+    python_requires=">=3.9,<4"
     requires=plugin_requires,
     additional_packages=plugin_additional_packages,
     ignored_packages=plugin_ignored_packages,


### PR DESCRIPTION
This should prevent issues like #284 

https://stackoverflow.com/a/48777286
https://setuptools.pypa.io/en/latest/references/keywords.html