### PR TITLE
Avoid excessive switches on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 5
 
+### 5.0.2
+
+- Fixed excessive switches for inverted relays on startup.
+
 ### 5.0.1
 
 - Preventing installations on environments having unsupported Python versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 5.0.2
 
-- Fixed excessive switches for inverted relays on startup.
+- Initial state for relays is `OFF` — fixes excessive switches on startup in most cases.
 
 ### 5.0.1
 

--- a/octoprint_octorelay/driver.py
+++ b/octoprint_octorelay/driver.py
@@ -11,7 +11,7 @@ class Driver():
     def __init__(self, pin: int, inverted: bool, pin_factory=None):
         self.pin = pin # GPIO pin
         self.inverted = inverted # marks the relay as normally closed
-        self.handle = LED(pin, pin_factory=pin_factory, initial_value=None)
+        self.handle = LED(pin, pin_factory=pin_factory, initial_value=inverted)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(pin={self.pin},inverted={self.inverted},closed={self.is_closed()})"

--- a/octoprint_octorelay/driver.py
+++ b/octoprint_octorelay/driver.py
@@ -11,7 +11,7 @@ class Driver():
     def __init__(self, pin: int, inverted: bool, pin_factory=None):
         self.pin = pin # GPIO pin
         self.inverted = inverted # marks the relay as normally closed
-        self.handle = LED(pin, pin_factory=pin_factory)
+        self.handle = LED(pin, pin_factory=pin_factory, initial_value=None)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(pin={self.pin},inverted={self.inverted},closed={self.is_closed()})"

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -18,7 +18,7 @@ class TestDriver(unittest.TestCase):
         self.assertIsInstance(relay, Driver)
         self.assertEqual(relay.pin, 18)
         self.assertTrue(relay.inverted)
-        self.assertFalse(handle.is_lit) # turned off initially
+        self.assertFalse(relay.handle.is_lit) # turned off initially
 
     def test_serialization(self):
         relay = Driver(18, True, MockFactory())

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -22,7 +22,7 @@ class TestDriver(unittest.TestCase):
     def test_serialization(self):
         relay = Driver(18, True, MockFactory())
         serialization = f"{relay}"
-        self.assertEqual(serialization, "Driver(pin=18,inverted=True,closed=True)")
+        self.assertEqual(serialization, "Driver(pin=18,inverted=True,closed=False)")
 
     def test_close(self):
         cases = [

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -18,7 +18,6 @@ class TestDriver(unittest.TestCase):
         self.assertIsInstance(relay, Driver)
         self.assertEqual(relay.pin, 18)
         self.assertTrue(relay.inverted)
-        self.assertFalse(relay.handle.is_lit) # turned off initially
 
     def test_serialization(self):
         relay = Driver(18, True, MockFactory())

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -18,6 +18,7 @@ class TestDriver(unittest.TestCase):
         self.assertIsInstance(relay, Driver)
         self.assertEqual(relay.pin, 18)
         self.assertTrue(relay.inverted)
+        self.assertFalse(handle.is_lit) # turned off initially
 
     def test_serialization(self):
         relay = Driver(18, True, MockFactory())


### PR DESCRIPTION
If relay is inverted, `gpiozero` sets its initial value to `false`, which turns it on, because `false` is the default initial value in docs:

https://gpiozero.readthedocs.io/en/latest/api_output.html#led