### PR TITLE
Performance tuning for number formatting

### DIFF
--- a/ui/__snapshots__/qa.spec.ts.snap
+++ b/ui/__snapshots__/qa.spec.ts.snap
@@ -107,10 +107,25 @@ var closeBtnHTML = \`<button id="\${closeBtnId}" type="button" class="close">\${
 
 // helpers/countdown.ts
 var createNumberFormat = _.memoize(
-  (...[locale, options]) => new Intl.NumberFormat(locale, options),
+  (...[requested, options]) => {
+    const locales = [requested];
+    if (typeof requested === "string" && requested.includes("_")) {
+      locales.push(requested.replaceAll("_", "-"));
+    }
+    locales.push(void 0);
+    for (const locale of locales) {
+      try {
+        return new Intl.NumberFormat(locale, options);
+      } catch (error) {
+        console.warn(\`Failed to format time using \${locale} locale\`, error);
+      }
+    }
+    const format = (value) => \`\${value} \${options == null ? void 0 : options.unit}\${value === 1 ? "" : "s"}\`;
+    return { format };
+  },
   (...[locale, options]) => [locale, options == null ? void 0 : options.unit, options == null ? void 0 : options.maximumFractionDigits].join("|")
 );
-var formatDeadline = (time, locales = [LOCALE, void 0]) => {
+var formatDeadline = (time) => {
   let unit = "second";
   let timeLeft = (time - Date.now()) / 1e3;
   if (timeLeft >= 60) {
@@ -122,22 +137,14 @@ var formatDeadline = (time, locales = [LOCALE, void 0]) => {
     unit = "hour";
   }
   const isLastMinute = unit === "minute" && timeLeft < 2;
-  const nonNegTimeLeft = Math.max(0, timeLeft);
-  for (const locale of locales) {
-    try {
-      const formattedTimeLeft = createNumberFormat(locale, {
-        style: "unit",
-        unitDisplay: "long",
-        minimumFractionDigits: isLastMinute ? 1 : 0,
-        maximumFractionDigits: isLastMinute ? 1 : 0,
-        unit
-      }).format(nonNegTimeLeft);
-      return \`in \${formattedTimeLeft}\`;
-    } catch (error) {
-      console.warn(\`Failed to format time using \${locale} locale\`, error);
-    }
-  }
-  return \`in \${nonNegTimeLeft} \${unit}\${nonNegTimeLeft === 1 ? "" : "s"}\`;
+  const formattedTimeLeft = createNumberFormat(LOCALE, {
+    style: "unit",
+    unitDisplay: "long",
+    minimumFractionDigits: isLastMinute ? 1 : 0,
+    maximumFractionDigits: isLastMinute ? 1 : 0,
+    unit
+  }).format(Math.max(0, timeLeft));
+  return \`in \${formattedTimeLeft}\`;
 };
 var getCountdownDelay = (deadline) => deadline - Date.now() > 12e4 ? 6e4 : 1e3;
 var setCountdown = (selector, deadline) => {

--- a/ui/__snapshots__/qa.spec.ts.snap
+++ b/ui/__snapshots__/qa.spec.ts.snap
@@ -106,6 +106,10 @@ var closeIconHTML = '<span class="fa fa-close fa-sm"></span>';
 var closeBtnHTML = \`<button id="\${closeBtnId}" type="button" class="close">\${closeIconHTML}</button>\`;
 
 // helpers/countdown.ts
+var createNumberFormat = _.memoize(
+  (...[locale, options]) => new Intl.NumberFormat(locale, options),
+  (...[locale, options]) => [locale, options == null ? void 0 : options.unit, options == null ? void 0 : options.maximumFractionDigits].join("|")
+);
 var formatDeadline = (time, locales = [LOCALE, void 0]) => {
   let unit = "second";
   let timeLeft = (time - Date.now()) / 1e3;
@@ -121,7 +125,7 @@ var formatDeadline = (time, locales = [LOCALE, void 0]) => {
   const nonNegTimeLeft = Math.max(0, timeLeft);
   for (const locale of locales) {
     try {
-      const formattedTimeLeft = new Intl.NumberFormat(locale, {
+      const formattedTimeLeft = createNumberFormat(locale, {
         style: "unit",
         unitDisplay: "long",
         minimumFractionDigits: isLastMinute ? 1 : 0,

--- a/ui/__snapshots__/qa.spec.ts.snap
+++ b/ui/__snapshots__/qa.spec.ts.snap
@@ -106,7 +106,7 @@ var closeIconHTML = '<span class="fa fa-close fa-sm"></span>';
 var closeBtnHTML = \`<button id="\${closeBtnId}" type="button" class="close">\${closeIconHTML}</button>\`;
 
 // helpers/countdown.ts
-var formatDeadline = (time) => {
+var formatDeadline = (time, locales = [LOCALE, void 0]) => {
   let unit = "second";
   let timeLeft = (time - Date.now()) / 1e3;
   if (timeLeft >= 60) {
@@ -118,14 +118,21 @@ var formatDeadline = (time) => {
     unit = "hour";
   }
   const isLastMinute = unit === "minute" && timeLeft < 2;
-  const formattedTimeLeft = new Intl.NumberFormat(LOCALE, {
-    style: "unit",
-    unitDisplay: "long",
-    minimumFractionDigits: isLastMinute ? 1 : 0,
-    maximumFractionDigits: isLastMinute ? 1 : 0,
-    unit
-  }).format(Math.max(0, timeLeft));
-  return \`in \${formattedTimeLeft}\`;
+  for (const locale of locales) {
+    try {
+      const formattedTimeLeft = new Intl.NumberFormat(locale, {
+        style: "unit",
+        unitDisplay: "long",
+        minimumFractionDigits: isLastMinute ? 1 : 0,
+        maximumFractionDigits: isLastMinute ? 1 : 0,
+        unit
+      }).format(Math.max(0, timeLeft));
+      return \`in \${formattedTimeLeft}\`;
+    } catch (error) {
+      console.warn(\`Failed to format time using \${locale} locale\`, error);
+    }
+  }
+  return \`in \${timeLeft} \${unit}\${timeLeft > 1 ? "s" : ""}\`;
 };
 var getCountdownDelay = (deadline) => deadline - Date.now() > 12e4 ? 6e4 : 1e3;
 var setCountdown = (selector, deadline) => {

--- a/ui/helpers/countdown.spec.ts
+++ b/ui/helpers/countdown.spec.ts
@@ -50,6 +50,7 @@ describe("Countdown helpers", () => {
     test.each([
       [10000, "10 seconds"],
       [60000, "1 minute"],
+      [-10000, "0 seconds"],
     ])(`should handle invalid locales %#`, (offset, label) => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       expect(

--- a/ui/helpers/countdown.spec.ts
+++ b/ui/helpers/countdown.spec.ts
@@ -1,4 +1,5 @@
 import MockDate from "mockdate";
+import assert from "node:assert";
 import { elementMock, jQueryMock } from "../mocks/jQuery";
 import { lodashMock } from "../mocks/lodash";
 import {
@@ -12,6 +13,7 @@ import {
 } from "vitest";
 
 describe("Countdown helpers", async () => {
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   const setIntervalMock = vi.fn<(handler: () => void, delay: number) => void>(
     () => "mockedInterval",
   );
@@ -34,6 +36,10 @@ describe("Countdown helpers", async () => {
   });
 
   afterEach(() => {
+    Object.assign(global, {
+      LOCALE: "en",
+    });
+    warnSpy.mockClear();
     setIntervalMock.mockClear();
     clearIntervalMock.mockClear();
     elementMock.text.mockClear();
@@ -49,21 +55,15 @@ describe("Countdown helpers", async () => {
       "Should format the supplied UNIX timestamp having offset %s seconds",
       (offset) => {
         expect(formatDeadline(Date.now() + offset * 1000)).toMatchSnapshot();
+        expect(warnSpy).not.toHaveBeenCalled();
       },
     );
 
-    test.each([
-      [10000, "10 seconds"],
-      [60000, "1 minute"],
-      [-10000, "0 seconds"],
-    ])(`should handle invalid locales %#`, (offset, label) => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      expect(
-        formatDeadline(Date.now() + offset, [
-          "invalid_locale_id",
-          "another_invalid_one",
-        ]),
-      ).toBe(`in ${label}`);
+    test("should handle invalid locales", () => {
+      Object.assign(global, {
+        LOCALE: "invalid_locale_id",
+      });
+      expect(formatDeadline(Date.now() + 10000)).toBe(`in 10 seconds`);
       expect(warnSpy).toHaveBeenCalledTimes(2);
       expect(warnSpy.mock.calls).toEqual([
         [
@@ -71,9 +71,24 @@ describe("Countdown helpers", async () => {
           expect.any(Error),
         ],
         [
-          "Failed to format time using another_invalid_one locale",
+          "Failed to format time using invalid-locale-id locale",
           expect.any(Error),
         ],
+      ]);
+    });
+
+    test.each([
+      [1000, "1 second"],
+      [10000, "10 seconds"],
+    ])("should handle complete Intl malfunction", (offset, expected) => {
+      vi.spyOn(Intl, "NumberFormat").mockImplementation(() =>
+        assert.fail("Can not do this"),
+      );
+      expect(formatDeadline(Date.now() + offset)).toBe(`in ${expected}`);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy.mock.calls).toEqual([
+        ["Failed to format time using en locale", expect.any(Error)],
+        ["Failed to format time using undefined locale", expect.any(Error)],
       ]);
     });
   });

--- a/ui/helpers/countdown.spec.ts
+++ b/ui/helpers/countdown.spec.ts
@@ -46,6 +46,30 @@ describe("Countdown helpers", () => {
         expect(formatDeadline(Date.now() + offset * 1000)).toMatchSnapshot();
       },
     );
+
+    test.each([
+      [10000, "10 seconds"],
+      [60000, "1 minute"],
+    ])(`should handle invalid locales %#`, (offset, label) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(
+        formatDeadline(Date.now() + offset, [
+          "invalid_locale_id",
+          "another_invalid_one",
+        ]),
+      ).toBe(`in ${label}`);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy.mock.calls).toEqual([
+        [
+          "Failed to format time using invalid_locale_id locale",
+          expect.any(Error),
+        ],
+        [
+          "Failed to format time using another_invalid_one locale",
+          expect.any(Error),
+        ],
+      ]);
+    });
   });
 
   describe("getCountdownDelay() helper", () => {

--- a/ui/helpers/countdown.spec.ts
+++ b/ui/helpers/countdown.spec.ts
@@ -1,6 +1,6 @@
 import MockDate from "mockdate";
 import { elementMock, jQueryMock } from "../mocks/jQuery";
-import { formatDeadline, getCountdownDelay, setCountdown } from "./countdown";
+import { lodashMock } from "../mocks/lodash";
 import {
   describe,
   vi,
@@ -11,7 +11,7 @@ import {
   test,
 } from "vitest";
 
-describe("Countdown helpers", () => {
+describe("Countdown helpers", async () => {
   const setIntervalMock = vi.fn<(handler: () => void, delay: number) => void>(
     () => "mockedInterval",
   );
@@ -20,9 +20,14 @@ describe("Countdown helpers", () => {
   Object.assign(global, {
     LOCALE: "en",
     $: jQueryMock,
+    _: lodashMock,
     setInterval: setIntervalMock,
     clearInterval: clearIntervalMock,
   });
+
+  const { formatDeadline, getCountdownDelay, setCountdown } = await import(
+    "./countdown"
+  );
 
   beforeAll(() => {
     MockDate.set("2023-08-13T22:30:00");

--- a/ui/helpers/countdown.ts
+++ b/ui/helpers/countdown.ts
@@ -10,14 +10,21 @@ export const formatDeadline = (time: number): string => {
     unit = "hour";
   }
   const isLastMinute = unit === "minute" && timeLeft < 2;
-  const formattedTimeLeft = new Intl.NumberFormat(LOCALE, {
-    style: "unit",
-    unitDisplay: "long",
-    minimumFractionDigits: isLastMinute ? 1 : 0,
-    maximumFractionDigits: isLastMinute ? 1 : 0,
-    unit,
-  }).format(Math.max(0, timeLeft));
-  return `in ${formattedTimeLeft}`;
+  for (const locale of [LOCALE, undefined]) {
+    try {
+      const formattedTimeLeft = new Intl.NumberFormat(locale, {
+        style: "unit",
+        unitDisplay: "long",
+        minimumFractionDigits: isLastMinute ? 1 : 0,
+        maximumFractionDigits: isLastMinute ? 1 : 0,
+        unit,
+      }).format(Math.max(0, timeLeft));
+      return `in ${formattedTimeLeft}`;
+    } catch (error) {
+      console.warn(`Failed to format time using ${locale} locale`, error);
+    }
+  }
+  return `in ${time} seconds`;
 };
 
 export const getCountdownDelay = (deadline: number): number =>

--- a/ui/helpers/countdown.ts
+++ b/ui/helpers/countdown.ts
@@ -1,3 +1,11 @@
+/** @desc Creating Intl.NumberFormat is relatively slow, therefore using memoize() per set of arguments */
+const createNumberFormat = _.memoize(
+  (...[locale, options]: Parameters<typeof Intl.NumberFormat>) =>
+    new Intl.NumberFormat(locale, options),
+  (...[locale, options]: Parameters<typeof Intl.NumberFormat>) =>
+    [locale, options?.unit, options?.maximumFractionDigits].join("|"),
+);
+
 export const formatDeadline = (
   time: number,
   locales = [LOCALE, undefined],
@@ -16,7 +24,7 @@ export const formatDeadline = (
   const nonNegTimeLeft = Math.max(0, timeLeft);
   for (const locale of locales) {
     try {
-      const formattedTimeLeft = new Intl.NumberFormat(locale, {
+      const formattedTimeLeft = createNumberFormat(locale, {
         style: "unit",
         unitDisplay: "long",
         minimumFractionDigits: isLastMinute ? 1 : 0,

--- a/ui/helpers/countdown.ts
+++ b/ui/helpers/countdown.ts
@@ -13,6 +13,7 @@ export const formatDeadline = (
     unit = "hour";
   }
   const isLastMinute = unit === "minute" && timeLeft < 2;
+  const nonNegTimeLeft = Math.max(0, timeLeft);
   for (const locale of locales) {
     try {
       const formattedTimeLeft = new Intl.NumberFormat(locale, {
@@ -21,13 +22,13 @@ export const formatDeadline = (
         minimumFractionDigits: isLastMinute ? 1 : 0,
         maximumFractionDigits: isLastMinute ? 1 : 0,
         unit,
-      }).format(Math.max(0, timeLeft));
+      }).format(nonNegTimeLeft);
       return `in ${formattedTimeLeft}`;
     } catch (error) {
       console.warn(`Failed to format time using ${locale} locale`, error);
     }
   }
-  return `in ${timeLeft} ${unit}${timeLeft > 1 ? "s" : ""}`;
+  return `in ${nonNegTimeLeft} ${unit}${nonNegTimeLeft === 1 ? "" : "s"}`;
 };
 
 export const getCountdownDelay = (deadline: number): number =>

--- a/ui/helpers/countdown.ts
+++ b/ui/helpers/countdown.ts
@@ -1,4 +1,7 @@
-/** @desc Creating Intl.NumberFormat is relatively slow, therefore using memoize() per set of arguments */
+/**
+ * @desc Creating Intl.NumberFormat is relatively slow, therefore using memoize() per set of arguments
+ * @since 5.1.0 also iterating over the requested locale, fixed locale and default one, then falling back to custom
+ * */
 const createNumberFormat = _.memoize(
   (
     ...[requested, options]: Parameters<typeof Intl.NumberFormat>

--- a/ui/helpers/countdown.ts
+++ b/ui/helpers/countdown.ts
@@ -1,4 +1,7 @@
-export const formatDeadline = (time: number): string => {
+export const formatDeadline = (
+  time: number,
+  locales = [LOCALE, undefined],
+): string => {
   let unit: "second" | "minute" | "hour" = "second";
   let timeLeft = (time - Date.now()) / 1000;
   if (timeLeft >= 60) {
@@ -10,7 +13,7 @@ export const formatDeadline = (time: number): string => {
     unit = "hour";
   }
   const isLastMinute = unit === "minute" && timeLeft < 2;
-  for (const locale of [LOCALE, undefined]) {
+  for (const locale of locales) {
     try {
       const formattedTimeLeft = new Intl.NumberFormat(locale, {
         style: "unit",
@@ -24,7 +27,7 @@ export const formatDeadline = (time: number): string => {
       console.warn(`Failed to format time using ${locale} locale`, error);
     }
   }
-  return `in ${time} seconds`;
+  return `in ${timeLeft} ${unit}${timeLeft > 1 ? "s" : ""}`;
 };
 
 export const getCountdownDelay = (deadline: number): number =>

--- a/ui/helpers/countdown.ts
+++ b/ui/helpers/countdown.ts
@@ -1,13 +1,11 @@
 /** @desc Creating Intl.NumberFormat is relatively slow, therefore using memoize() per set of arguments */
 const createNumberFormat = _.memoize(
   (...[requested, options]: Parameters<typeof Intl.NumberFormat>) => {
-    const locales = [requested]
-      .concat(
-        typeof requested === "string" && requested.includes("_")
-          ? requested.replaceAll("_", "-")
-          : [],
-      )
-      .concat(undefined);
+    const locales = [requested];
+    if (typeof requested === "string" && requested.includes("_")) {
+      locales.push(requested.replaceAll("_", "-"));
+    }
+    locales.push(undefined);
     for (const locale of locales) {
       try {
         return new Intl.NumberFormat(locale, options);

--- a/ui/helpers/countdown.ts
+++ b/ui/helpers/countdown.ts
@@ -1,6 +1,8 @@
 /** @desc Creating Intl.NumberFormat is relatively slow, therefore using memoize() per set of arguments */
 const createNumberFormat = _.memoize(
-  (...[requested, options]: Parameters<typeof Intl.NumberFormat>) => {
+  (
+    ...[requested, options]: Parameters<typeof Intl.NumberFormat>
+  ): Pick<Intl.NumberFormat, "format"> => {
     const locales = [requested];
     if (typeof requested === "string" && requested.includes("_")) {
       locales.push(requested.replaceAll("_", "-"));
@@ -13,10 +15,9 @@ const createNumberFormat = _.memoize(
         console.warn(`Failed to format time using ${locale} locale`, error);
       }
     }
-    return {
-      format: (value: number) =>
-        `${value} ${options?.unit}${value === 1 ? "" : "s"}`,
-    } satisfies Pick<Intl.NumberFormat, "format">;
+    const format = (value: number) =>
+      `${value} ${options?.unit}${value === 1 ? "" : "s"}`;
+    return { format };
   },
   (...[locale, options]: Parameters<typeof Intl.NumberFormat>) =>
     [locale, options?.unit, options?.maximumFractionDigits].join("|"),

--- a/ui/mocks/lodash.ts
+++ b/ui/mocks/lodash.ts
@@ -1,0 +1,5 @@
+import { vi } from "vitest";
+
+export const lodashMock = {
+  memoize: vi.fn((fn: () => unknown) => fn),
+};

--- a/ui/mocks/lodash.ts
+++ b/ui/mocks/lodash.ts
@@ -1,5 +1,7 @@
 import { vi } from "vitest";
 
 export const lodashMock = {
-  memoize: vi.fn((fn: () => unknown) => fn),
+  memoize: vi.fn(
+    (fn: () => unknown, resolver: () => unknown) => resolver() && fn,
+  ),
 };

--- a/ui/octorelay.spec.ts
+++ b/ui/octorelay.spec.ts
@@ -1,12 +1,14 @@
-import { initOctoRelayModel } from "./model/initOctoRelayModel";
+import { lodashMock } from "./mocks/lodash";
 import { describe, vi, test, expect } from "vitest";
 
 describe("Entrypoint", () => {
   const jQueryMock = vi.fn();
   Object.assign(global, {
     $: jQueryMock,
+    _: lodashMock,
   });
   test("Should set the document onLoad handler", async () => {
+    const { initOctoRelayModel } = await import("./model/initOctoRelayModel");
     await import("./octorelay");
     expect(jQueryMock).toHaveBeenCalledWith(initOctoRelayModel);
   });

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@tsconfig/node18": "^18.2.4",
     "@types/jquery": "^3.5.30",
+    "@types/lodash": "^3.10.9",
     "@types/node": "^22.5.2",
     "@vitest/coverage-istanbul": "^2.0.5",
     "eslint": "^9.12.0",

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "ES6",
     "module": "ES2022",
     "moduleResolution": "Bundler",
-    "removeComments": true
+    "removeComments": true,
+    "allowUmdGlobalAccess": true
   },
   "exclude": [
     "node_modules"

--- a/ui/types/OctoPrint.d.ts
+++ b/ui/types/OctoPrint.d.ts
@@ -40,8 +40,6 @@ interface ViewModel {
 declare const OCTOPRINT_VIEWMODELS: Array<ViewModel>;
 /** @see https://github.com/OctoPrint/OctoPrint/blob/1.5.3/src/octoprint/templates/initscript.jinja2#L32 */
 declare const LOCALE: string;
-/** @see https://github.com/OctoPrint/OctoPrint/blob/1.5.3/src/octoprint/static/js/lib/lodash.js */
-declare const _: LoDashStatic;
 
 /** @see https://github.com/OctoPrint/OctoPrint/blob/1.9.0/docs/jsclientlib/base.rst */
 declare const OctoPrint: {

--- a/ui/types/OctoPrint.d.ts
+++ b/ui/types/OctoPrint.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="jquery" />
+/// <reference types="lodash" />
 
 interface JQuery {
   /** @see https://github.com/OctoPrint/OctoPrint/blob/1.9.0/src/octoprint/static/js/lib/bootstrap/bootstrap-modal.js */
@@ -37,7 +38,10 @@ interface ViewModel {
 }
 
 declare const OCTOPRINT_VIEWMODELS: Array<ViewModel>;
+/** @see https://github.com/OctoPrint/OctoPrint/blob/1.5.3/src/octoprint/templates/initscript.jinja2#L32 */
 declare const LOCALE: string;
+/** @see https://github.com/OctoPrint/OctoPrint/blob/1.5.3/src/octoprint/static/js/lib/lodash.js */
+declare const _: LoDashStatic;
 
 /** @see https://github.com/OctoPrint/OctoPrint/blob/1.9.0/docs/jsclientlib/base.rst */
 declare const OctoPrint: {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -743,6 +743,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/lodash@^3.10.9":
+  version "3.10.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-3.10.9.tgz#8e2276d0b1d60a0d3820268f85705f77ec482c5e"
+  integrity sha512-BqzpDcDNIj0D15QezYF2C8OhOZVsm3g9Y6bLfXC6jO+wgxDGdCJlzge9OqnI0RezYJNsfsGXovhb3zTZjHpiCA==
+
 "@types/node@^22.5.2":
   version "22.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"


### PR DESCRIPTION
addition to #319 
This improves the performance on number formatting being instantiated in a cycle.
The approach is to use the lodash.memoize() which is integrated within OctoPrint, v3.10.1

```
 ✓ intl.bench.ts (2) 2610ms
   ✓ Intl performance (2) 2608ms
     name                             hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · new Intl.NumberFormat     89,964.12  0.0097  0.8449  0.0111  0.0114  0.0166  0.0256  0.0648  ±1.09%    44983
   · memoized               4,063,946.37  0.0002  0.8680  0.0002  0.0002  0.0003  0.0004  0.0010  ±0.76%  2031974   fastest


 BENCH  Summary

  memoized - intl.bench.ts > Intl performance
    45.17x faster than new Intl.NumberFormat
```