### PR TITLE
Supporting Python 3.13

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -113,6 +113,14 @@ jobs:
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
+      - name: Make liblgpio.so
+        if: ${{ matrix.python == '3.13' }}
+        run: |
+          wget https://abyz.me.uk/lg/lg.zip
+          unzip lg.zip
+          cd lg
+          make
+          sudo make install
       - name: Install OctoRelay
         run: pip install -e .
       - name: Prepare testing environment

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -113,6 +113,11 @@ jobs:
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
+      - name: Swig correction
+        run: |
+          apt-get remove swig
+          apt-get install swig3.0
+          ln -s /usr/bin/swig3.0 /usr/bin/swig
       - name: Install OctoRelay
         run: pip install -e .
       - name: Prepare testing environment

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -113,6 +113,9 @@ jobs:
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
+      - name: Install octoprint-setuptools
+        if: ${{ matrix.octoprint == '1.11' }}
+        run: pip install "octoprint-setuptools>=1.0.0"
       - name: Make liblgpio.so
         if: ${{ matrix.python == '3.13' }}
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -61,26 +61,38 @@ jobs:
             python: 3.11
           - octoprint: 1.5
             python: 3.12
+          - octoprint: 1.5
+            python: 3.13
           - octoprint: 1.6
             python: 3.10
           - octoprint: 1.6
             python: 3.11
           - octoprint: 1.6
             python: 3.12
+          - octoprint: 1.6
+            python: 3.13
           - octoprint: 1.7
             python: 3.10
           - octoprint: 1.7
             python: 3.11
           - octoprint: 1.7
             python: 3.12
+          - octoprint: 1.7
+            python: 3.13
           - octoprint: 1.8
             python: 3.10
           - octoprint: 1.8
             python: 3.11
           - octoprint: 1.8
             python: 3.12
+          - octoprint: 1.8
+            python: 3.13
           - octoprint: 1.9
             python: 3.12
+          - octoprint: 1.9
+            python: 3.13
+          - octoprint: 1.10
+            python: 3.13
     steps:
       - uses: actions/checkout@v4
       - name: Install Python

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -99,8 +99,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Upgrade pip
-        run: pip install --upgrade pip
       - name: Get pip cache dir
         id: pipCache
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
@@ -115,9 +113,8 @@ jobs:
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
-      - name: Install octoprint-setuptools
-        if: ${{ matrix.octoprint == '1.11' }}
-        run: pip install "octoprint-setuptools>=1.0.0"
+      - name: Fixed setuptools
+        run: pip install "setuptools~=79.0.0"
       - name: Make liblgpio.so
         if: ${{ matrix.python == '3.13' }}
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [ "3.9", "3.10", "3.11", "3.12" ]
+        python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         octoprint: [ "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11" ]
         exclude:
           # These versions are not compatible to each other:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -113,11 +113,6 @@ jobs:
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
-      - name: Swig correction
-        run: |
-          apt-get remove swig
-          apt-get install swig3.0
-          ln -s /usr/bin/swig3.0 /usr/bin/swig
       - name: Install OctoRelay
         run: pip install -e .
       - name: Prepare testing environment

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -99,6 +99,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Get pip cache dir
         id: pipCache
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -114,9 +114,11 @@ jobs:
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
       - name: Fixed setuptools
+        # see https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
         run: pip install "setuptools~=79.0.0"
       - name: Make liblgpio.so
         if: ${{ matrix.python == '3.13' }}
+        # see https://github.com/borisbu/OctoRelay/issues/346#issuecomment-2849009685
         run: |
           wget https://abyz.me.uk/lg/lg.zip
           unzip lg.zip


### PR DESCRIPTION
OctoPrint 1.11 now supports Python 3.13
https://github.com/OctoPrint/OctoPrint/releases/tag/1.11.0