### PR TITLE
CI: downgrading `setuptools`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -101,6 +101,9 @@ jobs:
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
+      - name: Fixed setuptools
+        # see https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
+        run: pip install "setuptools~=79.0.0"
       - name: Install OctoRelay
         run: pip install -e .
       - name: Prepare testing environment


### PR DESCRIPTION
There was a breaking change to setuptools, that affects the CI in #345 and #348 
Proper fix requires investigation and migrating to a different setup approach