### PR TITLE
Undo setuptools downgrade, add toml file.

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -113,9 +113,6 @@ jobs:
       - name: Install Wheel
         # see https://community.octoprint.org/t/setuptools-error-while-installing-plugin-octoklipper-on-manual-op-installation/51387
         run: pip install wheel
-      - name: Fixed setuptools
-        # see https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
-        run: pip install "setuptools~=79.0.0"
       - name: Make liblgpio.so
         if: ${{ matrix.python == '3.13' }}
         # see https://github.com/borisbu/OctoRelay/issues/346#issuecomment-2849009685

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "octoprint-setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixed #350 
Reverts #349 
Following the example in https://github.com/OctoPrint/OctoPrint/issues/4552#issuecomment-1313974191
