### PR TITLE
fix(api): Enabling API protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Modernized the build system: no longer use `setup.py`, now using `pyproject.toml` solely;
 - Plugin versioning switched from `miniver` to `setuptools-scm`;
-- Release file format remains `.zip` for automatic updates, but may be changed in the future v6.
+- Release file format remains `.zip` for automatic updates, but may be changed in the future v6;
+- Excplicitly enabled the plugin API protection: authentication required (`X-Api-Key`).
 
 ### 5.3.0
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -93,6 +93,10 @@ class OctoRelayPlugin(
             CANCEL_TASK_COMMAND: [ "subject", "target", "owner" ]
         }
 
+    def is_api_protected(self):
+        # https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.SimpleApiPlugin.is_api_protected
+        return True
+
     def get_additional_permissions(self, *args, **kwargs):
         return [ SWITCH_PERMISSION ]
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -406,6 +406,10 @@ class TestOctoRelayPlugin(unittest.TestCase):
         actual = self.plugin_instance.get_api_commands()
         self.assertEqual(actual, expected)
 
+    def test_is_api_protected(self):
+        # Should return True to enforce API key authentication for SimpleApi endpoints
+        self.assertTrue(self.plugin_instance.is_api_protected())
+
     def test_get_update_information(self):
         # Should return the update strategy configuration
         expected = {


### PR DESCRIPTION
Related to #373 

The protection is actually in place, but implicitly.
This PR makes it explicit.

https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.SimpleApiPlugin.is_api_protected