### PR TITLE
fix(template): Enabling exclicit autoescape.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Modernized the build system: no longer use `setup.py`, now using `pyproject.toml` solely;
 - Plugin versioning switched from `miniver` to `setuptools-scm`;
 - Release file format remains `.zip` for automatic updates, but may be changed in the future v6;
-- Excplicitly enabled the plugin API protection: authentication required (`X-Api-Key`).
+- Explicitly enabled the plugin API protection: authentication required (`X-Api-Key`);
+- Explicitly enabled template autoescaping to prevent potential XSS vulnerabilities.
 
 ### 5.3.0
 

--- a/octoprint_octorelay/__init__.py
+++ b/octoprint_octorelay/__init__.py
@@ -97,6 +97,10 @@ class OctoRelayPlugin(
         # https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.SimpleApiPlugin.is_api_protected
         return True
 
+    def is_template_autoescaped(self):
+        # https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.TemplatePlugin.is_template_autoescaped
+        return True
+
     def get_additional_permissions(self, *args, **kwargs):
         return [ SWITCH_PERMISSION ]
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -410,6 +410,10 @@ class TestOctoRelayPlugin(unittest.TestCase):
         # Should return True to enforce API key authentication for SimpleApi endpoints
         self.assertTrue(self.plugin_instance.is_api_protected())
 
+    def test_is_template_autoescaped(self):
+        # Should return True to enable autoescaping for templates, preventing XSS
+        self.assertTrue(self.plugin_instance.is_template_autoescaped())
+
     def test_get_update_information(self):
         # Should return the update strategy configuration
         expected = {


### PR DESCRIPTION
Related to #373 

https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.TemplatePlugin.is_template_autoescaped

It's already enabled implicitly since OctoPrint 1.13 but this PR makes it explicit.
See https://community.octoprint.org/t/how-do-i-improve-my-plugins-security-by-enabling-autoescape/61067